### PR TITLE
Replaces Player object references with UUIDs

### DIFF
--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.helion3.prism.api.flags.*;
 import com.helion3.prism.api.parameters.ParameterCause;
@@ -42,7 +43,6 @@ import ninja.leaping.configurate.loader.ConfigurationLoader;
 
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
@@ -74,13 +74,13 @@ import com.helion3.prism.storage.mysql.MySQLStorageAdapter;
  */
 @Plugin(id = "prism", name = "Prism", version = "3.0.0")
 final public class Prism {
-    private static List<Player> activeWands = new ArrayList<>();
+    private static List<UUID> activeWands = new ArrayList<>();
     private static final FilterList filterlist = new FilterList(FilterMode.BLACKLIST);
     private static Configuration config;
     private static Game game;
     private static List<ParameterHandler> handlers = new ArrayList<>();
     private static List<FlagHandler> flagHandlers = new ArrayList<>();
-    private static Map<Player, List<ActionableResult>> lastActionResults = new HashMap<>();
+    private static Map<UUID, List<ActionableResult>> lastActionResults = new HashMap<>();
     private static Logger logger;
     private static Map<String,Class<? extends Result>> resultRecords = new HashMap<>();
     private static File parentDirectory;
@@ -156,9 +156,9 @@ final public class Prism {
     /**
      * Returns a list of players who have active inspection wands.
      *
-     * @return List of Players.
+     * @return A list of players' UUIDs who have an active inspection wand
      */
-    public static List<Player> getActiveWands() {
+    public static List<UUID> getActiveWands() {
         return activeWands;
     }
 
@@ -197,9 +197,10 @@ final public class Prism {
 
     /**
      * Get a map of players and their last available actionable results.
-     * @return
+     *
+     * @return A map of players' UUIDs to a list of their {@link ActionableResult}s
      */
-    public static Map<Player, List<ActionableResult>> getLastActionResults() {
+    public static Map<UUID, List<ActionableResult>> getLastActionResults() {
         return lastActionResults;
     }
 

--- a/src/main/java/com/helion3/prism/commands/ApplierCommand.java
+++ b/src/main/java/com/helion3/prism/commands/ApplierCommand.java
@@ -135,7 +135,7 @@ public class ApplierCommand {
                                 ));
 
                                 if (source instanceof Player) {
-                                    Prism.getLastActionResults().put((Player) source, actionResults);
+                                    Prism.getLastActionResults().put(((Player) source).getUniqueId(), actionResults);
                                 }
                             }
                         });

--- a/src/main/java/com/helion3/prism/commands/InspectCommand.java
+++ b/src/main/java/com/helion3/prism/commands/InspectCommand.java
@@ -40,11 +40,11 @@ public class InspectCommand {
             if (source instanceof Player) {
                 Player player = (Player) source;
 
-                if (Prism.getActiveWands().contains(player)) {
-                    Prism.getActiveWands().remove(player);
+                if (Prism.getActiveWands().contains(player.getUniqueId())) {
+                    Prism.getActiveWands().remove(player.getUniqueId());
                     source.sendMessage(Format.heading("Inspection wand disabled."));
                 } else {
-                    Prism.getActiveWands().add(player);
+                    Prism.getActiveWands().add(player.getUniqueId());
                     source.sendMessage(Format.heading("Inspection wand enabled."));
                 }
             }

--- a/src/main/java/com/helion3/prism/commands/UndoCommand.java
+++ b/src/main/java/com/helion3/prism/commands/UndoCommand.java
@@ -54,7 +54,7 @@ public class UndoCommand {
                     return CommandResult.empty();
                 }
 
-                List<ActionableResult> results = Prism.getLastActionResults().get(source);
+                List<ActionableResult> results = Prism.getLastActionResults().get(((Player) source).getUniqueId());
                 if (results == null) {
                     source.sendMessage(Format.error("You have no valid actions to undo."));
                     return CommandResult.empty();

--- a/src/main/java/com/helion3/prism/events/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/ChangeBlockListener.java
@@ -47,7 +47,7 @@ public class ChangeBlockListener {
     @Listener
     public void onChangeBlock(final ChangeBlockEvent event) {
         Optional<Player> playerCause = event.getCause().first(Player.class);
-        if (playerCause.isPresent() && Prism.getActiveWands().contains(playerCause.get())) {
+        if (playerCause.isPresent() && Prism.getActiveWands().contains(playerCause.get().getUniqueId())) {
             // Cancel and exit event here, not supposed to place/track a block with an active wand.
             event.setCancelled(true);
             return;

--- a/src/main/java/com/helion3/prism/events/listeners/RequiredInteractListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/RequiredInteractListener.java
@@ -55,7 +55,7 @@ public class RequiredInteractListener {
         Optional<Player> playerCause = event.getCause().first(Player.class);
 
         // Wand support
-        if (playerCause.isPresent() && Prism.getActiveWands().contains(playerCause.get())) {
+        if (playerCause.isPresent() && Prism.getActiveWands().contains(playerCause.get().getUniqueId())) {
             if (event instanceof InteractBlockEvent) {
                 QuerySession session = new QuerySession(playerCause.get());
                 session.addFlag(Flag.EXTENDED);


### PR DESCRIPTION
Due to a change a while ago in Sponge, where `Player` objects are often recreated, it has become unsafe and a possible source of a memory leak to store references to them, so I switched the code to use `UUID`s instead.