### PR TITLE
Switches license to use normal block comment style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ license {
     sourceSets = project.sourceSets
     ignoreFailures false
     strictCheck true
+    mapping {
+        java = 'SLASHSTAR_STYLE'
+    }
 }
 
 checkstyle {

--- a/src/main/java/com/helion3/prism/Configuration.java
+++ b/src/main/java/com/helion3/prism/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/Listening.java
+++ b/src/main/java/com/helion3/prism/Listening.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/filters/FilterList.java
+++ b/src/main/java/com/helion3/prism/api/filters/FilterList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/filters/FilterMode.java
+++ b/src/main/java/com/helion3/prism/api/filters/FilterMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/Flag.java
+++ b/src/main/java/com/helion3/prism/api/flags/Flag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagClean.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagClean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagDrain.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagDrain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagExtended.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagExtended.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagHandler.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagNoGroup.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagNoGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/FlagOrder.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/flags/SimpleFlagHandler.java
+++ b/src/main/java/com/helion3/prism/api/flags/SimpleFlagHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterBlock.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterCause.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterCause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterEventName.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterEventName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterException.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterHandler.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterPlayer.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterPlayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterRadius.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterRadius.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/ParameterTime.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/parameters/SimpleParameterHandler.java
+++ b/src/main/java/com/helion3/prism/api/parameters/SimpleParameterHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/Condition.java
+++ b/src/main/java/com/helion3/prism/api/query/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/ConditionGroup.java
+++ b/src/main/java/com/helion3/prism/api/query/ConditionGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/FieldCondition.java
+++ b/src/main/java/com/helion3/prism/api/query/FieldCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/MatchRule.java
+++ b/src/main/java/com/helion3/prism/api/query/MatchRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/Query.java
+++ b/src/main/java/com/helion3/prism/api/query/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
+++ b/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/QuerySession.java
+++ b/src/main/java/com/helion3/prism/api/query/QuerySession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/QueryValueMutator.java
+++ b/src/main/java/com/helion3/prism/api/query/QueryValueMutator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/SQLQuery.java
+++ b/src/main/java/com/helion3/prism/api/query/SQLQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/query/Sort.java
+++ b/src/main/java/com/helion3/prism/api/query/Sort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/Actionable.java
+++ b/src/main/java/com/helion3/prism/api/records/Actionable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/ActionableResult.java
+++ b/src/main/java/com/helion3/prism/api/records/ActionableResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/BlockResult.java
+++ b/src/main/java/com/helion3/prism/api/records/BlockResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/EntityResult.java
+++ b/src/main/java/com/helion3/prism/api/records/EntityResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/PrismRecord.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/Result.java
+++ b/src/main/java/com/helion3/prism/api/records/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/ResultAggregate.java
+++ b/src/main/java/com/helion3/prism/api/records/ResultAggregate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/ResultComplete.java
+++ b/src/main/java/com/helion3/prism/api/records/ResultComplete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/SerializableNonExistant.java
+++ b/src/main/java/com/helion3/prism/api/records/SerializableNonExistant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/records/SkipReason.java
+++ b/src/main/java/com/helion3/prism/api/records/SkipReason.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageAdapter.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageAdapterRecords.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageAdapterRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageAdapterSettings.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageAdapterSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageDeleteResult.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageDeleteResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageResult.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/api/storage/StorageWriteResult.java
+++ b/src/main/java/com/helion3/prism/api/storage/StorageWriteResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/ApplierCommand.java
+++ b/src/main/java/com/helion3/prism/commands/ApplierCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/ExtinguishCommand.java
+++ b/src/main/java/com/helion3/prism/commands/ExtinguishCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/HelpCommand.java
+++ b/src/main/java/com/helion3/prism/commands/HelpCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/InspectCommand.java
+++ b/src/main/java/com/helion3/prism/commands/InspectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/LookupCommand.java
+++ b/src/main/java/com/helion3/prism/commands/LookupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/NearCommand.java
+++ b/src/main/java/com/helion3/prism/commands/NearCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/PrismCommands.java
+++ b/src/main/java/com/helion3/prism/commands/PrismCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/commands/UndoCommand.java
+++ b/src/main/java/com/helion3/prism/commands/UndoCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/ChangeBlockListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/ChangeInventoryListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/ChangeInventoryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/DeathListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/DeathListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/DropItemListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/DropItemListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/JoinListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/JoinListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/QuitListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/QuitListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/events/listeners/RequiredInteractListener.java
+++ b/src/main/java/com/helion3/prism/events/listeners/RequiredInteractListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/queues/RecordingQueue.java
+++ b/src/main/java/com/helion3/prism/queues/RecordingQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/queues/RecordingQueueManager.java
+++ b/src/main/java/com/helion3/prism/queues/RecordingQueueManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/h2/H2Records.java
+++ b/src/main/java/com/helion3/prism/storage/h2/H2Records.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/h2/H2SQLQuery.java
+++ b/src/main/java/com/helion3/prism/storage/h2/H2SQLQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/h2/H2StorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/h2/H2StorageAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/mongodb/MongoRecords.java
+++ b/src/main/java/com/helion3/prism/storage/mongodb/MongoRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/mongodb/MongoStorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/mongodb/MongoStorageAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLQuery.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLRecords.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/AsyncCallback.java
+++ b/src/main/java/com/helion3/prism/util/AsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/AsyncUtil.java
+++ b/src/main/java/com/helion3/prism/util/AsyncUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/BlockUtil.java
+++ b/src/main/java/com/helion3/prism/util/BlockUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/CauseUtil.java
+++ b/src/main/java/com/helion3/prism/util/CauseUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/DataQueries.java
+++ b/src/main/java/com/helion3/prism/util/DataQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/DataUtil.java
+++ b/src/main/java/com/helion3/prism/util/DataUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/DateUtil.java
+++ b/src/main/java/com/helion3/prism/util/DateUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/EventUtil.java
+++ b/src/main/java/com/helion3/prism/util/EventUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/Format.java
+++ b/src/main/java/com/helion3/prism/util/Format.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/Messages.java
+++ b/src/main/java/com/helion3/prism/util/Messages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/Template.java
+++ b/src/main/java/com/helion3/prism/util/Template.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/Translation.java
+++ b/src/main/java/com/helion3/prism/util/Translation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/TypeUtil.java
+++ b/src/main/java/com/helion3/prism/util/TypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/

--- a/src/main/java/com/helion3/prism/util/WorldUtil.java
+++ b/src/main/java/com/helion3/prism/util/WorldUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Prism, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2015 Helion3 http://helion3.com/


### PR DESCRIPTION
This is more consistent with other people who include the license as a header. The license is not a Javadoc so it makes more sense. 