### PR TITLE
Clean up usage of Optionals

### DIFF
--- a/src/main/java/com/helion3/prism/api/flags/FlagClean.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagClean.java
@@ -51,7 +51,7 @@ public class FlagClean extends SimpleFlagHandler {
     }
 
     @Override
-    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, Optional<String> value, Query query) {
+    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, @Nullable String value, Query query) {
         session.addFlag(Flag.CLEAN);
         return Optional.empty();
     }

--- a/src/main/java/com/helion3/prism/api/flags/FlagDrain.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagDrain.java
@@ -53,7 +53,7 @@ public class FlagDrain extends SimpleFlagHandler {
     }
 
     @Override
-    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, Optional<String> value, Query query) {
+    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, @Nullable String value, Query query) {
         session.addFlag(Flag.DRAIN);
         return Optional.empty();
     }

--- a/src/main/java/com/helion3/prism/api/flags/FlagExtended.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagExtended.java
@@ -51,7 +51,7 @@ public class FlagExtended extends SimpleFlagHandler {
     }
 
     @Override
-    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, Optional<String> value, Query query) {
+    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, @Nullable String value, Query query) {
         session.addFlag(Flag.EXTENDED);
         session.addFlag(Flag.NO_GROUP);
         return Optional.empty();

--- a/src/main/java/com/helion3/prism/api/flags/FlagHandler.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagHandler.java
@@ -67,5 +67,5 @@ public interface FlagHandler {
      * @param value String value(s) given with flag
      * @param query Query Current query object
      */
-    Optional<CompletableFuture<?>> process(QuerySession session, String flag, Optional<String> value, Query query);
+    Optional<CompletableFuture<?>> process(QuerySession session, @Nullable String flag, String value, Query query);
 }

--- a/src/main/java/com/helion3/prism/api/flags/FlagNoGroup.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagNoGroup.java
@@ -53,7 +53,7 @@ public class FlagNoGroup extends SimpleFlagHandler {
     }
 
     @Override
-    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, Optional<String> value, Query query) {
+    public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, @Nullable String value, Query query) {
         session.addFlag(Flag.NO_GROUP);
         return Optional.empty();
     }

--- a/src/main/java/com/helion3/prism/api/flags/FlagOrder.java
+++ b/src/main/java/com/helion3/prism/api/flags/FlagOrder.java
@@ -62,9 +62,9 @@ public class FlagOrder extends SimpleFlagHandler {
     }
 
     @Override
-    public Optional<CompletableFuture<?>> process(QuerySession session, String flag, Optional<String> value, Query query) {
-        if (value.isPresent()) {
-            switch (value.get()) {
+    public Optional<CompletableFuture<?>> process(QuerySession session, String flag, @Nullable String value, Query query) {
+        if (value != null) {
+            switch (value) {
                 case "new":
                 case "newest":
                 case "desc":

--- a/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
+++ b/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
@@ -161,13 +161,13 @@ public class QueryBuilder {
         flag = flag.substring(1);
 
         // Determine the true alias and value
-        Optional<String> optionalValue = Optional.empty();
+        String value = null;
         if (flag.contains("=")) {
             // Split the parameter: values
             String[] split = flag.split("=");
             flag = split[0];
             if (split.length == 2 && !split[1].trim().isEmpty()) {
-                optionalValue = Optional.of(split[1]);
+                value = split[1];
             }
         }
 
@@ -185,11 +185,11 @@ public class QueryBuilder {
         }
 
         // Validate value
-        if (optionalValue.isPresent() && !handler.acceptsValue(optionalValue.get())) {
-            throw new ParameterException("Invalid value \"" + optionalValue.get() + "\" for parameter \"" + flag + "\".");
+        if (value != null && !handler.acceptsValue(value)) {
+            throw new ParameterException("Invalid value \"" + value + "\" for parameter \"" + flag + "\".");
         }
 
-        return handler.process(session, flag, optionalValue, query);
+        return handler.process(session, flag, value, query);
     }
 
     /**

--- a/src/main/java/com/helion3/prism/api/records/ActionableResult.java
+++ b/src/main/java/com/helion3/prism/api/records/ActionableResult.java
@@ -32,7 +32,7 @@ import org.spongepowered.api.data.Transaction;
 public class ActionableResult {
     private final boolean changeWasApplied;
     private final SkipReason skipReason;
-    private final Optional<Transaction<?>> transaction;
+    private final Transaction<?> transaction;
 
     /**
      * Build a skipped actionable result.
@@ -53,13 +53,13 @@ public class ActionableResult {
     }
 
     private ActionableResult(@Nullable Transaction<?> transaction) {
-        this.transaction = Optional.ofNullable(transaction);
+        this.transaction = transaction;
         this.changeWasApplied = true;
         this.skipReason = null;
     }
 
     private ActionableResult(SkipReason skipReason) {
-        this.transaction = Optional.empty();
+        this.transaction = null;
         this.changeWasApplied = false;
         this.skipReason = skipReason;
     }
@@ -77,7 +77,7 @@ public class ActionableResult {
      * @return Optional transaction.
      */
     public Optional<Transaction<?>> getTransaction() {
-        return transaction;
+        return Optional.ofNullable(transaction);
     }
 
     /**

--- a/src/main/java/com/helion3/prism/api/records/BlockResult.java
+++ b/src/main/java/com/helion3/prism/api/records/BlockResult.java
@@ -25,6 +25,7 @@ package com.helion3.prism.api.records;
 
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.MemoryDataContainer;
@@ -36,6 +37,8 @@ import com.helion3.prism.Prism;
 import com.helion3.prism.util.BlockUtil;
 import com.helion3.prism.util.DataQueries;
 import org.spongepowered.api.world.BlockChangeFlag;
+
+import javax.annotation.Nonnull;
 
 /**
  * Represents a block change event record.
@@ -60,7 +63,7 @@ public class BlockResult extends ResultComplete implements Actionable {
         }
 
         // Format
-        finalBlock = formatBlockData(finalBlock, optionalLocation);
+        finalBlock = formatBlockData(finalBlock, optionalLocation.get());
 
         Optional<BlockSnapshot> optionalSnapshot = Prism.getGame().getRegistry().createBuilder(Builder.class).build(finalBlock);
         if (!optionalSnapshot.isPresent()) {
@@ -88,8 +91,9 @@ public class BlockResult extends ResultComplete implements Actionable {
         return ActionableResult.success(new Transaction<>(original, resultingBlock));
     }
 
-    public DataView formatBlockData(DataView finalBlock, Optional<Object> optionalLocation) {
-        DataView location = (MemoryDataView) optionalLocation.get();
+    public DataView formatBlockData(DataView finalBlock, @Nonnull Object optionalLocation) {
+        Preconditions.checkNotNull(optionalLocation, "The location you are formatting cannot be null.");
+        DataView location = (MemoryDataView) optionalLocation;
         DataView position = new MemoryDataContainer();
         position.set(DataQueries.X, location.get(DataQueries.X).get());
         position.set(DataQueries.Y, location.get(DataQueries.Y).get());
@@ -131,7 +135,7 @@ public class BlockResult extends ResultComplete implements Actionable {
         }
 
         // Format
-        finalBlock = formatBlockData(finalBlock, optionalLocation);
+        finalBlock = formatBlockData(finalBlock, optionalLocation.get());
 
         Optional<BlockSnapshot> optionalSnapshot = Prism.getGame().getRegistry().createBuilder(Builder.class).build(finalBlock);
         if (!optionalSnapshot.isPresent()) {


### PR DESCRIPTION
Optionals are not really intended to be used as fields or parameters, but more as a return type. Nulls are fine to work with and using these as Optionals just adds extra overhead for the GC and it needs to wrap and unwrap Optionals as well, which is more unneccesary work.