### PR TITLE
[Proposal] Changes the CommandSource in QuerySession to not be an Optional

### DIFF
--- a/src/main/java/com/helion3/prism/api/parameters/ParameterRadius.java
+++ b/src/main/java/com/helion3/prism/api/parameters/ParameterRadius.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.api.command.CommandSource;
@@ -64,16 +65,17 @@ public class ParameterRadius extends SimpleParameterHandler {
 
     @Override
     public Optional<CompletableFuture<?>> process(QuerySession session, String parameter, String value, Query query) {
-        if (session.getCommandSource().get() instanceof Player) {
-            Location<World> location = ((Player) session.getCommandSource().get()).getLocation();
+        if (session.getCommandSource() instanceof Player) {
+            Player player = (Player) session.getCommandSource();
+            Location<World> location = player.getLocation();
 
             int radius = Integer.parseInt(value);
             int maxRadius = Prism.getConfig().getNode("limits", "radius", "max").getInt();
 
             // Enforce max radius unless player has override perms
-            if (radius > maxRadius && !session.getCommandSource().get().hasPermission("prism.override.radius")) {
+            if (radius > maxRadius && !player.hasPermission("prism.override.radius")) {
                 // @todo move this
-                session.getCommandSource().get().sendMessage(Format.subduedHeading(String.format("Limiting radius to maximum of %d", maxRadius)));
+                player.sendMessage(Format.subduedHeading(String.format("Limiting radius to maximum of %d", maxRadius)));
                 radius = maxRadius;
             }
 
@@ -87,12 +89,12 @@ public class ParameterRadius extends SimpleParameterHandler {
 
     @Override
     public Optional<Pair<String, String>> processDefault(QuerySession session, Query query) {
-        if (session.getCommandSource().get() instanceof Player) {
+        if (session.getCommandSource() instanceof Player) {
             // Default radius from config
             int defaultRadius = Prism.getConfig().getNode("defaults", "radius").getInt();
 
             // Player location
-            Location<World> location = ((Player) session.getCommandSource().get()).getLocation();
+            Location<World> location = ((Player) session.getCommandSource()).getLocation();
 
             query.addCondition(ConditionGroup.from(location, defaultRadius));
 

--- a/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
+++ b/src/main/java/com/helion3/prism/api/query/QueryBuilder.java
@@ -142,7 +142,7 @@ public class QueryBuilder {
 
             // @todo should move this
             if (!defaultsUsed.isEmpty()) {
-                session.getCommandSource().get().sendMessage(Format.subduedHeading(Text.of(String.format("Defaults used: %s", defaultsUsed))));
+                session.getCommandSource().sendMessage(Format.subduedHeading(Text.of(String.format("Defaults used: %s", defaultsUsed))));
             }
         }
 
@@ -180,7 +180,7 @@ public class QueryBuilder {
         FlagHandler handler = optionalHandler.get();
 
         // Allows this command source?
-        if (!handler.acceptsSource(session.getCommandSource().get())) {
+        if (!handler.acceptsSource(session.getCommandSource())) {
             throw new ParameterException("This command source may not use the \"" + flag + "\" flag.");
         }
 
@@ -236,7 +236,7 @@ public class QueryBuilder {
         ParameterHandler handler = optionalHandler.get();
 
         // Allows this command source?
-        if (!handler.acceptsSource(session.getCommandSource().get())) {
+        if (!handler.acceptsSource(session.getCommandSource())) {
             throw new ParameterException("This command source may not use the \"" + parameter.getKey() + "\" parameter.");
         }
 

--- a/src/main/java/com/helion3/prism/api/query/QuerySession.java
+++ b/src/main/java/com/helion3/prism/api/query/QuerySession.java
@@ -23,6 +23,7 @@
  */
 package com.helion3.prism.api.query;
 
+import com.google.common.base.Preconditions;
 import org.spongepowered.api.command.CommandSource;
 
 import com.helion3.prism.api.flags.Flag;
@@ -30,9 +31,9 @@ import com.helion3.prism.api.parameters.ParameterException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -42,17 +43,15 @@ import javax.annotation.Nullable;
  */
 public class QuerySession {
     protected List<Flag> flags = new ArrayList<>();
-    protected final CommandSource commandSource;
+    protected CommandSource commandSource;
     protected Query query;
     protected int radius;
     protected Sort sort = Sort.NEWEST_FIRST;
 
-    /**
-     * Constructs a new session without any command source.
+    /*
+     * Disallow creation of a query session without a command source.
      */
-    public QuerySession() {
-        this.commandSource = null;
-    }
+    private QuerySession() {}
 
     /**
      * Constructs a new query session with a known command source.
@@ -62,7 +61,8 @@ public class QuerySession {
      *
      * @param commandSource CommandSource this session belongs to.
      */
-    public QuerySession(CommandSource commandSource) {
+    public QuerySession(@Nonnull CommandSource commandSource) {
+        Preconditions.checkNotNull(commandSource, "The specified command source cannot be null.");
         this.commandSource = commandSource;
     }
 
@@ -75,12 +75,12 @@ public class QuerySession {
     }
 
     /**
-     * Returns the command source this session belongs to, if any.
+     * Returns the command source this session belongs to
      *
      * @return CommandSource
      */
-    public Optional<CommandSource> getCommandSource(){
-        return Optional.ofNullable(commandSource);
+    public CommandSource getCommandSource(){
+        return commandSource;
     }
 
     /**

--- a/src/main/java/com/helion3/prism/util/AsyncUtil.java
+++ b/src/main/java/com/helion3/prism/util/AsyncUtil.java
@@ -47,12 +47,7 @@ public class AsyncUtil {
      * @param session QuerySession running this lookup.
      */
     public static void lookup(final QuerySession session) throws Exception {
-        if (!session.getCommandSource().isPresent()) {
-            // @todo handle this.
-            return;
-        }
-
-        CommandSource source = session.getCommandSource().get();
+        CommandSource source = session.getCommandSource();
 
         // Enforce lookup limits
         session.getQuery().setLimit(Prism.getConfig().getNode("query", "lookup", "limit").getInt());
@@ -69,12 +64,12 @@ public class AsyncUtil {
                         // Build paginated content
                         PaginationList.Builder builder = service.get().builder();
                         builder.contents(messages);
-                        builder.sendTo(session.getCommandSource().get());
+                        builder.sendTo(source);
                         builder.linesPerPage(5);
                     }
                 } else {
                     for (Result result : results) {
-                        session.getCommandSource().get().sendMessage(Messages.from(result, session.hasFlag(Flag.EXTENDED)));
+                        source.sendMessage(Messages.from(result, session.hasFlag(Flag.EXTENDED)));
                     }
                 }
             }
@@ -111,7 +106,7 @@ public class AsyncUtil {
                             callback.success(results);
                         }
                     } catch(Exception e) {
-                        session.getCommandSource().get().sendMessage(Format.error(e.getMessage()));
+                        session.getCommandSource().sendMessage(Format.error(e.getMessage()));
                         e.printStackTrace();
                     }
                 });


### PR DESCRIPTION
We were rarely even checking if it was present anyway, so there was going to be errors if it was not there, and we never created one without a `CommandSource`, so we just had unnecessary boxing and unboxing. If its planned to have a `QuerySession` without a command source in the future this could be rethought and we could add the necessary checks instead.