### PR TITLE
Add ignore fake player configuration

### DIFF
--- a/src/main/java/com/helion3/prism/Configuration.java
+++ b/src/main/java/com/helion3/prism/Configuration.java
@@ -134,7 +134,7 @@ public class Configuration {
 
             ConfigurationNode eventIgnoreFakePlayers = rootNode.getNode("events", "ignore-fakeplayers");
             if (eventIgnoreFakePlayers.isVirtual()) {
-                eventIgnoreFakePlayers.setValue(true);
+                eventIgnoreFakePlayers.setValue(false);
             }
 
             // Events

--- a/src/main/java/com/helion3/prism/Configuration.java
+++ b/src/main/java/com/helion3/prism/Configuration.java
@@ -132,6 +132,11 @@ public class Configuration {
                 dbH2TablePrefix.setValue("prism_");
             }
 
+            ConfigurationNode eventIgnoreFakePlayers = rootNode.getNode("events", "ignore-fakeplayers");
+            if (eventIgnoreFakePlayers.isVirtual()) {
+                eventIgnoreFakePlayers.setValue(true);
+            }
+
             // Events
             ConfigurationNode eventBlockBreak = rootNode.getNode("events", "break");
             if (eventBlockBreak.isVirtual()) {

--- a/src/main/java/com/helion3/prism/Listening.java
+++ b/src/main/java/com/helion3/prism/Listening.java
@@ -29,7 +29,7 @@ public class Listening {
     public final boolean DECAY;
     public final boolean DROP;
     public final boolean GROW;
-    public final boolean IGNORE_FAKEPLAYERS;
+    public final boolean IGNOREFAKEPLAYERS;
     public final boolean JOIN;
     public final boolean PICKUP;
     public final boolean PLACE;
@@ -41,7 +41,7 @@ public class Listening {
         DECAY = Prism.getConfig().getNode("events", "decay").getBoolean();
         DROP = Prism.getConfig().getNode("events", "drop").getBoolean();
         GROW = Prism.getConfig().getNode("events", "grow").getBoolean();
-        IGNORE_FAKEPLAYERS = Prism.getConfig().getNode("events", "ignore-fakeplayers").getBoolean();
+        IGNOREFAKEPLAYERS = Prism.getConfig().getNode("events", "ignore-fakeplayers").getBoolean();
         JOIN = Prism.getConfig().getNode("events", "join").getBoolean();
         PICKUP = Prism.getConfig().getNode("events", "pickup").getBoolean();
         PLACE = Prism.getConfig().getNode("events", "place").getBoolean();

--- a/src/main/java/com/helion3/prism/Listening.java
+++ b/src/main/java/com/helion3/prism/Listening.java
@@ -29,6 +29,7 @@ public class Listening {
     public final boolean DECAY;
     public final boolean DROP;
     public final boolean GROW;
+    public final boolean IGNORE_FAKEPLAYERS;
     public final boolean JOIN;
     public final boolean PICKUP;
     public final boolean PLACE;
@@ -40,6 +41,7 @@ public class Listening {
         DECAY = Prism.getConfig().getNode("events", "decay").getBoolean();
         DROP = Prism.getConfig().getNode("events", "drop").getBoolean();
         GROW = Prism.getConfig().getNode("events", "grow").getBoolean();
+        IGNORE_FAKEPLAYERS = Prism.getConfig().getNode("events", "ignore-fakeplayers").getBoolean();
         JOIN = Prism.getConfig().getNode("events", "join").getBoolean();
         PICKUP = Prism.getConfig().getNode("events", "pickup").getBoolean();
         PLACE = Prism.getConfig().getNode("events", "place").getBoolean();

--- a/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
@@ -52,6 +53,13 @@ public class ChangeBlockListener {
             event.setCancelled(true);
             return;
         }
+
+        Optional<TileEntity> teCause = event.getCause().first(TileEntity.class);
+        if (teCause.isPresent() && Prism.getConfig().getNode("events", "ignore-fakeplayers").getBoolean()){
+            // ignore fake player if set in the config
+            return;
+        }
+
         for (Transaction<BlockSnapshot> transaction : event.getTransactions()) {
             if (!transaction.isValid()) {
                 continue;

--- a/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
@@ -55,7 +55,7 @@ public class ChangeBlockListener {
         }
 
         Optional<TileEntity> teCause = event.getCause().first(TileEntity.class);
-        if (teCause.isPresent() && Prism.getConfig().getNode("events", "ignore-fakeplayers").getBoolean()){
+        if (teCause.isPresent() && Prism.listening.IGNORE_FAKEPLAYERS){
             // ignore fake player if set in the config
             return;
         }

--- a/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
@@ -55,7 +55,7 @@ public class ChangeBlockListener {
         }
 
         Optional<TileEntity> teCause = event.getCause().first(TileEntity.class);
-        if (teCause.isPresent() && Prism.listening.IGNORE_FAKEPLAYERS){
+        if (teCause.isPresent() && Prism.listening.IGNOREFAKEPLAYERS){
             // ignore fake player if set in the config
             return;
         }


### PR DESCRIPTION
I did a test run yesterday on my heavily modded server, after 2hours I had collected about 2 million events.
This adds an option to ignore Fake players for events that currently log them.

I wasn't sure where to put the configuration node, let me know if you have any concerns!