### PR TITLE
Gracefully shutdown storage connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ repositories {
 
 dependencies {
     provided("com.zaxxer:HikariCP:2.6.3")
-    shadow("org.mongodb:mongo-java-driver:3.8.1")
+    shadow("org.mongodb:mongo-java-driver:3.10.1")
     annotationProcessor("org.spongepowered:spongeapi:7.1.0")
     provided("org.spongepowered:spongeapi:7.1.0")
 }

--- a/src/main/java/com/helion3/prism/queues/RecordingQueueManager.java
+++ b/src/main/java/com/helion3/prism/queues/RecordingQueueManager.java
@@ -33,7 +33,7 @@ import com.helion3.prism.Prism;
 public class RecordingQueueManager implements Runnable {
 
     @Override
-    public void run() {
+    public synchronized void run() {
         List<DataContainer> eventsSaveBatch = new ArrayList<>();
 
         // Assume we're iterating everything in the queue

--- a/src/main/java/com/helion3/prism/storage/h2/H2StorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/h2/H2StorageAdapter.java
@@ -52,7 +52,7 @@ public class H2StorageAdapter implements StorageAdapter {
     private final SqlService sql = Sponge.getServiceManager().provide(SqlService.class).get();
     private final Path dbPath = Prism.getInstance().getPath().getParent().resolve(Prism.getInstance().getConfiguration().getNode("db", "name").getString());
     private final StorageAdapterRecords records;
-    private static DataSource db;
+    private static HikariDataSource db;
 
     /**
      * Create a new instance of the H2 storage adapter.
@@ -205,7 +205,7 @@ public class H2StorageAdapter implements StorageAdapter {
 
     @Override
     public void close() {
-        // @todo implement
+        db.close();
     }
 
     @Override

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
@@ -46,7 +46,7 @@ public class MySQLStorageAdapter implements StorageAdapter {
     private final String tablePrefix = Prism.getInstance().getConfiguration().getNode("db", "mysql", "tablePrefix").getString();
     private final int purgeBatchLimit = Prism.getInstance().getConfiguration().getNode("storage", "purgeBatchLimit").getInt();
     private final StorageAdapterRecords records;
-    private static DataSource db;
+    private static HikariDataSource db;
     private final String dns;
 
     /**
@@ -207,7 +207,7 @@ public class MySQLStorageAdapter implements StorageAdapter {
 
     @Override
     public void close() {
-        // @todo implement
+        db.close();
     }
 
     @Override


### PR DESCRIPTION
As pointed out in #123 
`"we are having issues with orphaned connections on our MariaDB instance which we believe is due to Prism"`

This PR ensures that the storage connections for H2, Mongo and MySQL get closed on shutdown and that any pending records get written to storage **before** said connections are closed.

Also updated Mongo dependency.