### PR TITLE
Storage data handling improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ repositories {
 
 dependencies {
     provided("com.zaxxer:HikariCP:2.6.3")
-    shadow("org.mongodb:mongo-java-driver:3.10.1")
+    shadow("org.mongodb:mongo-java-driver:3.10.2")
     annotationProcessor("org.spongepowered:spongeapi:7.1.0")
     provided("org.spongepowered:spongeapi:7.1.0")
 }

--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -187,7 +187,7 @@ public final class Prism {
         try {
             if (StringUtils.equalsIgnoreCase(engine, "h2")) {
                 storageAdapter = new H2StorageAdapter();
-            } else if (StringUtils.equalsIgnoreCase(engine, "mongo")) {
+            } else if (StringUtils.equalsAnyIgnoreCase(engine, "mongo", "mongodb")) {
                 storageAdapter = new MongoStorageAdapter();
             } else if (StringUtils.equalsIgnoreCase(engine, "mysql")) {
                 storageAdapter = new MySQLStorageAdapter();

--- a/src/main/java/com/helion3/prism/configuration/Configuration.java
+++ b/src/main/java/com/helion3/prism/configuration/Configuration.java
@@ -105,6 +105,7 @@ public class Configuration {
             }
 
             getConfig().getStorageCategory().setDatabase(configurationNode.getNode("db", "name").getString("prism"));
+            getConfig().getGeneralCategory().setSchemaVersion(1);
         }
 
         ConfigurationNode defaults = configurationNode.getNode("defaults");

--- a/src/main/java/com/helion3/prism/configuration/category/GeneralCategory.java
+++ b/src/main/java/com/helion3/prism/configuration/category/GeneralCategory.java
@@ -37,7 +37,7 @@ public class GeneralCategory {
     private boolean debug = false;
 
     @Setting(value = "schema-version")
-    private int schemaVersion = 1;
+    private int schemaVersion = 2;
 
     public String getDateFormat() {
         return dateFormat;

--- a/src/main/java/com/helion3/prism/storage/mongodb/MongoStorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/mongodb/MongoStorageAdapter.java
@@ -21,12 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.helion3.prism.storage.mongodb;
 
 import com.helion3.prism.Prism;
 import com.helion3.prism.api.storage.StorageAdapter;
 import com.helion3.prism.api.storage.StorageAdapterRecords;
 import com.helion3.prism.api.storage.StorageAdapterSettings;
+import com.helion3.prism.storage.mongodb.codec.PrimitiveArrayCodec;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
@@ -38,6 +40,8 @@ import com.mongodb.client.model.IndexOptions;
 import java.util.concurrent.TimeUnit;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
 
 public class MongoStorageAdapter implements StorageAdapter {
 
@@ -75,7 +79,12 @@ public class MongoStorageAdapter implements StorageAdapter {
                 Prism.getInstance().getConfig().getStorageCategory().getPassword().toCharArray()
         );
 
-        mongoClient = new MongoClient(address, credential, MongoClientOptions.builder().build());
+        CodecRegistry codecRegistry = CodecRegistries.fromRegistries(
+                MongoClient.getDefaultCodecRegistry(),
+                CodecRegistries.fromCodecs(new PrimitiveArrayCodec())
+        );
+
+        mongoClient = new MongoClient(address, credential, MongoClientOptions.builder().codecRegistry(codecRegistry).build());
 
         // @todo support auth: boolean auth = db.authenticate(myUserName, myPassword);
 

--- a/src/main/java/com/helion3/prism/storage/mongodb/codec/PrimitiveArrayCodec.java
+++ b/src/main/java/com/helion3/prism/storage/mongodb/codec/PrimitiveArrayCodec.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Prism, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2015 Helion3 http://helion3.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.helion3.prism.storage.mongodb.codec;
+
+import com.google.common.collect.Lists;
+import com.helion3.prism.util.PrimitiveArray;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.ByteCodec;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.IntegerCodec;
+import org.bson.codecs.LongCodec;
+
+import java.util.List;
+
+public class PrimitiveArrayCodec implements Codec<PrimitiveArray> {
+
+    private final ByteCodec byteCodec = new ByteCodec();
+    private final IntegerCodec integerCodec = new IntegerCodec();
+    private final LongCodec longCodec = new LongCodec();
+
+    @Override
+    public PrimitiveArray decode(BsonReader reader, DecoderContext decoderContext) {
+        reader.readStartDocument();
+        String key = reader.readString("key");
+
+        List<Object> value = Lists.newArrayList();
+        if (StringUtils.equals(key, PrimitiveArray.BYTE_ARRAY_ID)) {
+            reader.readName("value");
+            reader.readStartArray();
+            while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                value.add(byteCodec.decode(reader, decoderContext));
+            }
+
+            reader.readEndArray();
+        } else if (StringUtils.equals(key, PrimitiveArray.INT_ARRAY_ID)) {
+            reader.readName("value");
+            reader.readStartArray();
+            while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                value.add(integerCodec.decode(reader, decoderContext));
+            }
+
+            reader.readEndArray();
+        } else if (StringUtils.equals(key, PrimitiveArray.LONG_ARRAY_ID)) {
+            reader.readName("value");
+            reader.readStartArray();
+            while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                value.add(longCodec.decode(reader, decoderContext));
+            }
+
+            reader.readEndArray();
+        } else {
+            reader.readEndDocument();
+            throw new BsonInvalidOperationException("Unsupported primitive type");
+        }
+
+        reader.readEndDocument();
+        return new PrimitiveArray(key, value);
+    }
+
+    @Override
+    public void encode(BsonWriter writer, PrimitiveArray object, EncoderContext encoderContext) {
+        writer.writeStartDocument();
+        writer.writeString("key", object.getKey());
+
+        Object array = object.getArray();
+        if (array instanceof byte[]) {
+            writer.writeName("value");
+            writer.writeStartArray();
+            for (byte value : (byte[]) array) {
+                byteCodec.encode(writer, value, encoderContext);
+            }
+
+            writer.writeEndArray();
+        } else if (array instanceof int[]) {
+            writer.writeName("value");
+            writer.writeStartArray();
+            for (int value : (int[]) array) {
+                integerCodec.encode(writer, value, encoderContext);
+            }
+
+            writer.writeEndArray();
+        } else if (array instanceof long[]) {
+            writer.writeName("value");
+            writer.writeStartArray();
+            for (long value : (long[]) array) {
+                longCodec.encode(writer, value, encoderContext);
+            }
+
+            writer.writeEndArray();
+        } else {
+            writer.writeEndDocument();
+            throw new BsonInvalidOperationException("Unsupported primitive type");
+        }
+
+        writer.writeEndDocument();
+    }
+
+    @Override
+    public Class<PrimitiveArray> getEncoderClass() {
+        return PrimitiveArray.class;
+    }
+}

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLStorageAdapter.java
@@ -28,8 +28,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Date;
 
-import javax.sql.DataSource;
-
 import com.helion3.prism.Prism;
 import com.helion3.prism.api.storage.StorageAdapter;
 import com.helion3.prism.api.storage.StorageAdapterRecords;
@@ -117,7 +115,7 @@ public class MySQLStorageAdapter implements StorageAdapter {
                     + DataQueries.X + " int(10) NOT NULL, "
                     + DataQueries.Y + " smallint(5) NOT NULL, "
                     + DataQueries.Z + " int(10) NOT NULL, "
-                    + DataQueries.Target + " varchar(55), "
+                    + DataQueries.Target + " varchar(255), "
                     + DataQueries.Player + " binary(16), "
                     + DataQueries.Cause + " varchar(55), "
                     + "PRIMARY KEY (`id`), "
@@ -145,6 +143,17 @@ public class MySQLStorageAdapter implements StorageAdapter {
                     + ") ENGINE=InnoDB DEFAULT CHARACTER SET utf8 "
                     + "DEFAULT COLLATE utf8_general_ci;";
             conn.prepareStatement(extra).execute();
+
+            if (Prism.getInstance().getConfig().getGeneralCategory().getSchemaVersion() == 1) {
+                // Expand target: 55 -> 255
+                conn.prepareStatement(String.format("ALTER TABLE %srecords ALTER COLUMN %s varchar(255);",
+                        tablePrefix,
+                        DataQueries.Target
+                )).execute();
+
+                Prism.getInstance().getConfig().getGeneralCategory().setSchemaVersion(2);
+                Prism.getInstance().getConfiguration().saveConfiguration();
+            }
         }
     }
 

--- a/src/main/java/com/helion3/prism/util/DataUtil.java
+++ b/src/main/java/com/helion3/prism/util/DataUtil.java
@@ -29,7 +29,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.Map.Entry;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.helion3.prism.api.records.Result;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
+import org.apache.commons.lang3.text.translate.UnicodeEscaper;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataQuery;
@@ -46,6 +52,16 @@ import org.spongepowered.api.profile.GameProfile;
 
 public class DataUtil {
 
+    private static final CharSequenceTranslator CHAR_SEQUENCE_TRANSLATOR = StringEscapeUtils.ESCAPE_JAVA.with(
+            UnicodeEscaper.between(0, 47),
+            // 0 - 9
+            UnicodeEscaper.between(58, 64),
+            // A - Z
+            UnicodeEscaper.between(91, 96),
+            // a - z
+            UnicodeEscaper.between(123, Integer.MAX_VALUE)
+    );
+
     private DataUtil() {
     }
 
@@ -56,15 +72,73 @@ public class DataUtil {
      * @return boolean If object is a primitive type
      */
     public static boolean isPrimitiveType(Object object) {
-        return (object instanceof Boolean ||
-                object instanceof Byte ||
-                object instanceof Character ||
-                object instanceof Double ||
-                object instanceof Float ||
-                object instanceof Integer ||
-                object instanceof Long ||
-                object instanceof Short ||
-                object instanceof String);
+        return object instanceof Boolean
+                || object instanceof Byte
+                || object instanceof Character
+                || object instanceof Double
+                || object instanceof Float
+                || object instanceof Integer
+                || object instanceof Long
+                || object instanceof Short
+                || object instanceof String;
+    }
+
+    /**
+     * Encodes all non-alphanumeric characters in the provided DataQuery,
+     * the encodes parts are then joined with a non-encoded symbol.
+     *
+     * Fixes https://github.com/prism/Prism/issues/90
+     *
+     * @param dataQuery Unescaped DataQuery
+     * @return Escaped string
+     */
+    public static String escapeQuery(DataQuery dataQuery) {
+        List<String> parts = Lists.newArrayList();
+
+        for (String part : dataQuery.getParts()) {
+            parts.add(escape(part));
+        }
+
+        return StringUtils.join(parts, '/');
+    }
+
+    /**
+     * Encodes all non-alphanumeric characters in the provided String.
+     *
+     * @param string Unescaped string
+     * @return string Escaped string
+     */
+    public static String escape(String string) {
+        return CHAR_SEQUENCE_TRANSLATOR.translate(string);
+    }
+
+    /**
+     * Decodes all encoded characters in the provided String,
+     * the string is split by a non-encoded symbol and each part is then decoded
+     * and finally a DataQuery is created using the decoded parts.
+     *
+     * Fixes https://github.com/prism/Prism/issues/90
+     *
+     * @param string Escaped string
+     * @return Unescaped DataQuery
+     */
+    public static DataQuery unescapeQuery(String string) {
+        List<String> parts = Lists.newArrayList();
+        for (String part : StringUtils.split(string, '/')) {
+            parts.add(unescape(part));
+        }
+
+        return DataQuery.of(parts);
+    }
+
+    /**
+     * Decodes all encoded characters in the provided String.
+     *
+     * @param string Escaped string
+     * @return string Unescaped string
+     */
+    public static String unescape(String string) {
+        return StringEscapeUtils.unescapeJava(string);
     }
 
     /**
@@ -77,7 +151,7 @@ public class DataUtil {
         for (Entry<String, JsonElement> entry : json.entrySet()) {
             Optional<Object> value = jsonElementToObject(entry.getValue());
             if (value.isPresent()) {
-                data.set(DataQuery.of(entry.getKey()), value.get());
+                data.set(unescapeQuery(entry.getKey()), value.get());
             } else {
                 Prism.getInstance().getLogger().error(String.format("Failed to transform %s data.", entry.getKey()));
             }
@@ -93,33 +167,44 @@ public class DataUtil {
      * @return Optional<Object>
      */
     private static Optional<Object> jsonElementToObject(JsonElement element) {
-        Object result = null;
-
-        if (element.isJsonObject()) {
-            result = dataViewFromJson(element.getAsJsonObject());
-        }
-        else if (element.isJsonPrimitive()) {
-            JsonPrimitive prim = element.getAsJsonPrimitive();
-
-            if (prim.isBoolean()) {
-                result = prim.getAsBoolean();
+        if (element.isJsonArray()) {
+            List<Object> list = Lists.newArrayList();
+            JsonArray jsonArray = element.getAsJsonArray();
+            jsonArray.forEach(entry -> jsonElementToObject(entry).ifPresent(list::add));
+            return Optional.of(list);
+        } else if (element.isJsonObject()) {
+            JsonObject jsonObject = element.getAsJsonObject();
+            PrimitiveArray primitiveArray = PrimitiveArray.of(jsonObject);
+            if (primitiveArray != null) {
+                return Optional.of(primitiveArray.getArray());
             }
-            else if (prim.isNumber()) {
-                result = prim.getAsNumber().intValue();
-            }
-            else if (prim.isString()) {
-                result = prim.getAsString();
+
+            return Optional.of(dataViewFromJson(jsonObject));
+        } else if (element.isJsonPrimitive()) {
+            JsonPrimitive jsonPrimitive = element.getAsJsonPrimitive();
+            if (jsonPrimitive.isBoolean()) {
+                return Optional.of(jsonPrimitive.getAsBoolean());
+            } else if (jsonPrimitive.isNumber()) {
+                Number number = NumberUtils.createNumber(jsonPrimitive.getAsString());
+                if (number instanceof Byte) {
+                    return Optional.of(number.byteValue());
+                } else if (number instanceof Double) {
+                    return Optional.of(number.doubleValue());
+                } else if (number instanceof Float) {
+                    return Optional.of(number.floatValue());
+                } else if (number instanceof Integer) {
+                    return Optional.of(number.intValue());
+                } else if (number instanceof Long) {
+                    return Optional.of(number.longValue());
+                } else if (number instanceof Short) {
+                    return Optional.of(number.shortValue());
+                }
+            } else if (jsonPrimitive.isString()) {
+                return Optional.of(jsonPrimitive.getAsString());
             }
         }
-        else if (element.isJsonArray()) {
-            List<Object> list = new ArrayList<>();
-            JsonArray arr = element.getAsJsonArray();
-            arr.forEach(t -> jsonElementToObject(t).ifPresent(list::add));
 
-            result = list;
-        }
-
-        return Optional.ofNullable(result);
+        return Optional.empty();
     }
 
     /**
@@ -129,71 +214,58 @@ public class DataUtil {
      * @return JsonObject JsonObject representation of the DataView
      */
     public static JsonObject jsonFromDataView(DataView view) {
-        JsonObject json = new JsonObject();
+        JsonObject jsonObject = new JsonObject();
         Gson gson = new GsonBuilder().create();
 
         Set<DataQuery> keys = view.getKeys(false);
         for (DataQuery query : keys) {
-            Optional<Object> optional = view.get(query);
-            if (optional.isPresent()) {
-                String key = query.asString(".");
-                List<Object> convertedList = new ArrayList<>();
 
-                if (optional.get() instanceof List) {
+            String key = escapeQuery(query);
+            Object value = view.get(query).orElse(null);
 
-                    for (Object object : (List<?>) optional.get()) {
-
-                        if (object instanceof DataView) {
-                            convertedList.add(jsonFromDataView((DataView) object));
-                        }
-                        else if (object instanceof List) {
-                            convertedList.add(gson.toJsonTree(object).getAsJsonArray());
-                        }
-                        else if (object.getClass().isEnum()) {
-                            //convertedList.add(object.toString());
-                        }
-                        else if (DataUtil.isPrimitiveType(object)) {
-                            JsonArray array = gson.toJsonTree(optional.get()).getAsJsonArray();
-                            convertedList.add(array);
-                            break;
-                        }
-                        else if (object.getClass().isArray()) {
-                            JsonArray array = gson.toJsonTree(object).getAsJsonArray();
-                            convertedList.add(array);
-                        }
-                        else {
-                            Prism.getInstance().getLogger().error("Unsupported json list data type: " + object.getClass().getName() + " for key " + key);
-                        }
+            if (value == null) {
+                // continue
+            } else if (value instanceof Collection) {
+                List<Object> convertedList = Lists.newArrayList();
+                for (Object object : (Collection<?>) value) {
+                    if (object == null) {
+                        // continue
+                    } else if (object instanceof Collection) {
+                        convertedList.add(gson.toJsonTree(object));
+                    } else if (object instanceof DataView) {
+                        convertedList.add(jsonFromDataView((DataView) object));
+                    } else if (DataUtil.isPrimitiveType(object)) {
+                        convertedList.add(gson.toJsonTree(object));
+                    } else if (object.getClass().isArray()) {
+                        convertedList.add(gson.toJsonTree(new PrimitiveArray(object)));
+                    } else if (object.getClass().isEnum()) {
+                        // convertedList.add(object.toString());
+                    } else {
+                        Prism.getInstance().getLogger().error("Unsupported json list data type: " + object.getClass().getName() + " for key " + key);
                     }
 
                     if (!convertedList.isEmpty()) {
-                        JsonArray array = gson.toJsonTree(convertedList).getAsJsonArray();
-                        json.add(key, array);
+                        jsonObject.add(key, gson.toJsonTree(convertedList));
                     }
                 }
-                else if (optional.get() instanceof DataView) {
-                    json.add(key, jsonFromDataView((DataView) optional.get()));
-                }
-                else {
-                    Object obj = optional.get();
-
-                    if (obj instanceof String) {
-                        json.addProperty(key, (String) obj);
-                    }
-                    else if (obj instanceof Number) {
-                        json.addProperty(key, (Number) obj);
-                    }
-                    else if (obj instanceof Boolean) {
-                        json.addProperty(key, (Boolean) obj);
-                    }
-                    else if (obj instanceof Character) {
-                        json.addProperty(key, (Character) obj);
-                    }
-                }
+            } else if (value instanceof Boolean) {
+                jsonObject.addProperty(key, (Boolean) value);
+            } else if (value instanceof Character) {
+                jsonObject.addProperty(key, (Character) value);
+            } else if (value instanceof DataView) {
+                jsonObject.add(key, jsonFromDataView((DataView) value));
+            } else if (value instanceof Number) {
+                jsonObject.addProperty(key, (Number) value);
+            } else if (value instanceof String) {
+                jsonObject.addProperty(key, (String) value);
+            } else if (value.getClass().isArray()) {
+                jsonObject.add(key, gson.toJsonTree(new PrimitiveArray(value)));
+            } else {
+                // Prism.getInstance().getLogger().error("Unsupported json data type: " + value.getClass().getName() + " for key " + key);
             }
         }
 
-        return json;
+        return jsonObject;
     }
 
     /**

--- a/src/main/java/com/helion3/prism/util/PrimitiveArray.java
+++ b/src/main/java/com/helion3/prism/util/PrimitiveArray.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of Prism, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2015 Helion3 http://helion3.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.helion3.prism.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.bson.Document;
+
+import java.util.List;
+
+/**
+ * https://wiki.vg/NBT - NBT only supports Byte, Int and Long Arrays
+ */
+public class PrimitiveArray {
+
+    public static final String BYTE_ARRAY_ID = String.format("%s:byte", Reference.ID);
+    public static final String INT_ARRAY_ID = String.format("%s:int", Reference.ID);
+    public static final String LONG_ARRAY_ID = String.format("%s:long", Reference.ID);
+    private final String key;
+    private final List<?> value;
+
+    public PrimitiveArray(Object object) {
+        Preconditions.checkArgument(object != null);
+        Preconditions.checkArgument(object.getClass().isArray());
+
+        if (object instanceof byte[]) {
+            this.key = BYTE_ARRAY_ID;
+            this.value = fromByteArray((byte[]) object);
+        } else if (object instanceof int[]) {
+            this.key = INT_ARRAY_ID;
+            this.value = fromIntArray((int[]) object);
+        } else if (object instanceof long[]) {
+            this.key = LONG_ARRAY_ID;
+            this.value = fromLongArray((long[]) object);
+        } else {
+            throw new UnsupportedOperationException("Unsupported primitive type");
+        }
+    }
+
+    public PrimitiveArray(String key, List<?> value) {
+        Preconditions.checkArgument(StringUtils.equalsAny(key, BYTE_ARRAY_ID, INT_ARRAY_ID, LONG_ARRAY_ID));
+        this.key = key;
+        this.value = value;
+    }
+
+    public static PrimitiveArray of(Document document) {
+        if (document.size() != 2 || !(document.containsKey("key") && document.containsKey("value"))) {
+            return null;
+        }
+
+        if (!(document.get("key") instanceof String)) {
+            return null;
+        }
+
+        String key = document.getString("key");
+        if (!StringUtils.equalsAny(key, BYTE_ARRAY_ID, INT_ARRAY_ID, LONG_ARRAY_ID)) {
+            return null;
+        }
+
+        List<?> value = (List<?>) document.get("value");
+        if (value == null) {
+            return null;
+        }
+
+        return new PrimitiveArray(key, value);
+    }
+
+    public static PrimitiveArray of(JsonObject jsonObject) {
+        if (jsonObject.size() != 2 || !(jsonObject.has("key") && jsonObject.has("value"))) {
+            return null;
+        }
+
+        if (!jsonObject.get("key").isJsonPrimitive() || !jsonObject.getAsJsonPrimitive("key").isString()) {
+            return null;
+        }
+
+        String key = jsonObject.get("key").getAsString();
+        if (!StringUtils.equalsAny(key, BYTE_ARRAY_ID, INT_ARRAY_ID, LONG_ARRAY_ID)) {
+            return null;
+        }
+
+        List<Number> value = Lists.newArrayList();
+        JsonArray jsonArray = jsonObject.get("value").getAsJsonArray();
+        jsonArray.forEach(entry -> value.add(NumberUtils.createNumber(entry.getAsString())));
+        return new PrimitiveArray(key, value);
+    }
+
+    public Object getArray() {
+        if (StringUtils.equals(this.key, BYTE_ARRAY_ID)) {
+            return toByteArray(this.value);
+        } else if (StringUtils.equals(this.key, INT_ARRAY_ID)) {
+            return toIntArray(this.value);
+        } else if (StringUtils.equals(this.key, LONG_ARRAY_ID)) {
+            return toLongArray(this.value);
+        } else {
+            throw new UnsupportedOperationException("Unsupported primitive type");
+        }
+    }
+
+    private byte[] toByteArray(List<?> list) {
+        byte[] array = new byte[list.size()];
+        for (int index = 0; index < list.size(); index++) {
+            array[index] = (Byte) list.get(index);
+        }
+
+        return array;
+    }
+
+    private List<Byte> fromByteArray(byte[] array) {
+        List<Byte> list = Lists.newArrayList();
+        for (int index = 0; index < array.length; index++) {
+            list.add(index, array[index]);
+        }
+
+        return list;
+    }
+
+    private int[] toIntArray(List<?> list) {
+        int[] array = new int[list.size()];
+        for (int index = 0; index < list.size(); index++) {
+            array[index] = (Integer) list.get(index);
+        }
+
+        return array;
+    }
+
+    private List<Integer> fromIntArray(int[] array) {
+        List<Integer> list = Lists.newArrayList();
+        for (int index = 0; index < array.length; index++) {
+            list.add(index, array[index]);
+        }
+
+        return list;
+    }
+
+    private long[] toLongArray(List<?> list) {
+        long[] array = new long[list.size()];
+        for (int index = 0; index < list.size(); index++) {
+            array[index] = (Long) list.get(index);
+        }
+
+        return array;
+    }
+
+    private List<Long> fromLongArray(long[] array) {
+        List<Long> list = Lists.newArrayList();
+        for (int index = 0; index < array.length; index++) {
+            list.add(index, array[index]);
+        }
+
+        return list;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public List<?> getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
- Added 'mongodb' as an alias for Mongo Storage.
- Increased the size of Target (H2 & MySQL) and Json (H2 only) Columns to fix incompatibility with certain mods.
- Added PrimitiveArray class to help with de/serializing primitive arrays (NBTTagList).
- Decode/Encode all DataQueries going to or from Storage for compatibility with Storage implementations and to prevent the path from becoming invalid due to unexpected characters.
- Rewrote the de/serialization system to ensure the accuracy of values.
- Update mongo dependency.

- Fixes https://github.com/prism/Prism/issues/99 & https://github.com/prism/Prism/issues/64 for MongoDB:
Tested with OpenComputers Rack (opencomputers:rack)

- Fixes https://github.com/prism/Prism/issues/90:
Tested with EnderIO Simple Alloy Smelter (enderio:block_simple_alloy_smelter)