### PR TITLE
PrimitiveArray bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ repositories {
 
 dependencies {
     provided("com.zaxxer:HikariCP:2.6.3")
+    testCompile("org.junit.jupiter:junit-jupiter-engine:5.5.1")
     shadow("org.mongodb:mongo-java-driver:3.10.2")
+    testCompile("org.mongodb:mongo-java-driver:3.10.2")
     annotationProcessor("org.spongepowered:spongeapi:7.1.0")
     provided("org.spongepowered:spongeapi:7.1.0")
 }
@@ -103,4 +105,13 @@ jar {
 processResources {
     from("LICENSE.txt")
     rename("LICENSE.txt", "LICENSE-" + archivesBaseName + ".txt")
+}
+
+test {
+    testLogging {
+        exceptionFormat = "full"
+        showStandardStreams = true
+    }
+    
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ configurations {
     licenseMain.ext.organization = "Helion3"
     licenseMain.ext.url = "http://helion3.com/"
     licenseMain.ext.year = "2015"
+    licenseTest.ext.name = licenseMain.ext.name
+    licenseTest.ext.organization = licenseMain.ext.organization
+    licenseTest.ext.url = licenseMain.ext.url
+    licenseTest.ext.year = licenseMain.ext.year
     project.ext.buildNumber = project.hasProperty("buildNumber") ? buildNumber : "0"
     project.ext.ciSystem = project.hasProperty("ciSystem") ? ciSystem : "unknown"
     project.ext.commit = project.hasProperty("commit") ? commit : "unknown"

--- a/src/main/java/com/helion3/prism/storage/h2/H2Records.java
+++ b/src/main/java/com/helion3/prism/storage/h2/H2Records.java
@@ -159,11 +159,16 @@ public class H2Records implements StorageAdapterRecords {
                     data.set(DataQueries.Created, rs.getLong(DataQueries.Created.toString()));
 
                     if (rs.getString("json") != null) {
-                        JsonObject json = new JsonParser().parse(rs.getString("json")).getAsJsonObject();
-                        DataView extra = DataUtil.dataViewFromJson(json);
+                        try {
+                            JsonObject json = new JsonParser().parse(rs.getString("json")).getAsJsonObject();
+                            DataView extra = DataUtil.dataViewFromJson(json);
 
-                        for (DataQuery key : extra.getKeys(false)) {
-                            data.set(key, extra.get(key).get());
+                            for (DataQuery key : extra.getKeys(false)) {
+                                data.set(key, extra.get(key).get());
+                            }
+                        } catch (Exception ex) {
+                            Prism.getInstance().getLogger().error("Failed to deserialize {} at {}", target, loc.toString());
+                            throw ex;
                         }
                     }
                 }

--- a/src/main/java/com/helion3/prism/storage/mongodb/codec/PrimitiveArrayCodec.java
+++ b/src/main/java/com/helion3/prism/storage/mongodb/codec/PrimitiveArrayCodec.java
@@ -51,7 +51,7 @@ public class PrimitiveArrayCodec implements Codec<PrimitiveArray> {
         reader.readStartDocument();
         String key = reader.readString("key");
 
-        List<Object> value = Lists.newArrayList();
+        List<Number> value = Lists.newArrayList();
         if (StringUtils.equals(key, PrimitiveArray.BYTE_ARRAY_ID)) {
             reader.readName("value");
             reader.readStartArray();

--- a/src/main/java/com/helion3/prism/storage/mysql/MySQLRecords.java
+++ b/src/main/java/com/helion3/prism/storage/mysql/MySQLRecords.java
@@ -181,11 +181,16 @@ public class MySQLRecords implements StorageAdapterRecords {
                     data.set(DataQueries.Location, loc);
 
                     if (rs.getString("json") != null) {
-                        JsonObject json = new JsonParser().parse(rs.getString("json")).getAsJsonObject();
-                        DataView extra = DataUtil.dataViewFromJson(json);
+                        try {
+                            JsonObject json = new JsonParser().parse(rs.getString("json")).getAsJsonObject();
+                            DataView extra = DataUtil.dataViewFromJson(json);
 
-                        for (DataQuery key : extra.getKeys(false)) {
-                            data.set(key, extra.get(key).get());
+                            for (DataQuery key : extra.getKeys(false)) {
+                                data.set(key, extra.get(key).get());
+                            }
+                        } catch (Exception ex) {
+                            Prism.getInstance().getLogger().error("Failed to deserialize {} at {}", target, loc.toString());
+                            throw ex;
                         }
                     }
                 }

--- a/src/main/java/com/helion3/prism/util/PrimitiveArray.java
+++ b/src/main/java/com/helion3/prism/util/PrimitiveArray.java
@@ -43,7 +43,7 @@ public class PrimitiveArray {
     public static final String INT_ARRAY_ID = String.format("%s:int", Reference.ID);
     public static final String LONG_ARRAY_ID = String.format("%s:long", Reference.ID);
     private final String key;
-    private final List<?> value;
+    private final List<? extends Number> value;
 
     public PrimitiveArray(Object object) {
         Preconditions.checkArgument(object != null);
@@ -63,7 +63,7 @@ public class PrimitiveArray {
         }
     }
 
-    public PrimitiveArray(String key, List<?> value) {
+    public PrimitiveArray(String key, List<? extends Number> value) {
         Preconditions.checkArgument(StringUtils.equalsAny(key, BYTE_ARRAY_ID, INT_ARRAY_ID, LONG_ARRAY_ID));
         this.key = key;
         this.value = value;
@@ -83,7 +83,7 @@ public class PrimitiveArray {
             return null;
         }
 
-        List<?> value = (List<?>) document.get("value");
+        List<Number> value = document.getList("value", Number.class);
         if (value == null) {
             return null;
         }
@@ -123,10 +123,10 @@ public class PrimitiveArray {
         }
     }
 
-    private byte[] toByteArray(List<?> list) {
+    private byte[] toByteArray(List<? extends Number> list) {
         byte[] array = new byte[list.size()];
         for (int index = 0; index < list.size(); index++) {
-            array[index] = (Byte) list.get(index);
+            array[index] = list.get(index).byteValue();
         }
 
         return array;
@@ -141,10 +141,10 @@ public class PrimitiveArray {
         return list;
     }
 
-    private int[] toIntArray(List<?> list) {
+    private int[] toIntArray(List<? extends Number> list) {
         int[] array = new int[list.size()];
         for (int index = 0; index < list.size(); index++) {
-            array[index] = (Integer) list.get(index);
+            array[index] = list.get(index).intValue();
         }
 
         return array;
@@ -159,10 +159,10 @@ public class PrimitiveArray {
         return list;
     }
 
-    private long[] toLongArray(List<?> list) {
+    private long[] toLongArray(List<? extends Number> list) {
         long[] array = new long[list.size()];
         for (int index = 0; index < list.size(); index++) {
-            array[index] = (Long) list.get(index);
+            array[index] = list.get(index).longValue();
         }
 
         return array;

--- a/src/test/java/com/helion3/prism/util/PrimitiveArrayTest.java
+++ b/src/test/java/com/helion3/prism/util/PrimitiveArrayTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Prism, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2015 Helion3 http://helion3.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.helion3.prism.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PrimitiveArrayTest {
+
+    private static final byte[] BYTE_ARRAY = new byte[]{Byte.MIN_VALUE, 0, Byte.MAX_VALUE};
+    private static final int[] INT_ARRAY = new int[]{Integer.MIN_VALUE, 0, Integer.MAX_VALUE};
+    private static final long[] LONG_ARRAY = new long[]{Long.MIN_VALUE, 0, Long.MAX_VALUE};
+
+    @Test
+    public void testByteArrayFromByteArray() {
+        PrimitiveArray primitiveArray = new PrimitiveArray(BYTE_ARRAY);
+
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.BYTE_ARRAY_ID);
+        Assertions.assertArrayEquals(BYTE_ARRAY, (byte[]) primitiveArray.getArray());
+    }
+
+    @Test
+    public void testByteArrayFromJsonObject() {
+        JsonArray jsonArray = new JsonArray();
+        for (byte number : BYTE_ARRAY) {
+            jsonArray.add(number);
+        }
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("key", PrimitiveArray.BYTE_ARRAY_ID);
+        jsonObject.add("value", jsonArray);
+
+        PrimitiveArray primitiveArray = PrimitiveArray.of(jsonObject);
+
+        Assertions.assertNotNull(primitiveArray);
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.BYTE_ARRAY_ID);
+        Assertions.assertArrayEquals(BYTE_ARRAY, (byte[]) primitiveArray.getArray());
+    }
+
+    @Test
+    public void testIntArrayFromIntArray() {
+        PrimitiveArray primitiveArray = new PrimitiveArray(INT_ARRAY);
+
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.INT_ARRAY_ID);
+        Assertions.assertArrayEquals(INT_ARRAY, (int[]) primitiveArray.getArray());
+    }
+
+    @Test
+    public void testIntArrayFromJsonObject() {
+        JsonArray jsonArray = new JsonArray();
+        for (int number : INT_ARRAY) {
+            jsonArray.add(number);
+        }
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("key", PrimitiveArray.INT_ARRAY_ID);
+        jsonObject.add("value", jsonArray);
+
+        PrimitiveArray primitiveArray = PrimitiveArray.of(jsonObject);
+
+        Assertions.assertNotNull(primitiveArray);
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.INT_ARRAY_ID);
+        Assertions.assertArrayEquals(INT_ARRAY, (int[]) primitiveArray.getArray());
+    }
+
+    @Test
+    public void testLongArrayFromLongArray() {
+        PrimitiveArray primitiveArray = new PrimitiveArray(LONG_ARRAY);
+
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.LONG_ARRAY_ID);
+        Assertions.assertArrayEquals(LONG_ARRAY, (long[]) primitiveArray.getArray());
+    }
+
+    @Test
+    public void testLongArrayFromJsonObject() {
+        JsonArray jsonArray = new JsonArray();
+        for (long number : LONG_ARRAY) {
+            jsonArray.add(number);
+        }
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("key", PrimitiveArray.LONG_ARRAY_ID);
+        jsonObject.add("value", jsonArray);
+
+        PrimitiveArray primitiveArray = PrimitiveArray.of(jsonObject);
+
+        Assertions.assertNotNull(primitiveArray);
+        Assertions.assertEquals(primitiveArray.getKey(), PrimitiveArray.LONG_ARRAY_ID);
+        Assertions.assertArrayEquals(LONG_ARRAY, (long[]) primitiveArray.getArray());
+    }
+}


### PR DESCRIPTION
- Added a try-catch when de-serializing data to help identify the block/item that is causing issues.
- Fixed #138 , I wrongly assumed `NumberUtils::createNumber` would return the correct type for the value or that the type returned could be cast to the correct type.
- Added PrimitiveArrayTest to ensure that #138 doesn't reappear in future.