### PR TITLE
Fix NullPointerException on Shutdown

### DIFF
--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -216,12 +216,14 @@ public final class Prism {
         // Cancel all scheduled tasks
         Sponge.getScheduler().getScheduledTasks(getInstance()).forEach(Task::cancel);
 
-        // Flush any pending records
-        // If the scheduled task is still running this will block until it completes
-        recordingQueueManager.run();
+        if (getStorageAdapter() != null) {
+            // Flush any pending records
+            // If the scheduled task is still running this will block until it completes
+            recordingQueueManager.run();
 
-        // Shutdown storage
-        getStorageAdapter().close();
+            // Shutdown storage
+            getStorageAdapter().close();
+        }
     }
 
     public static Prism getInstance() {


### PR DESCRIPTION
If a server stopping issue occurs before or during the GameStartedServerEvent it can result in the GameStoppedServerEvent getting called before Prism has initialized