### PR TITLE
PrismRecordEvent to broadcast when PrismRecord created

### DIFF
--- a/src/main/java/com/helion3/prism/api/records/PrismRecord.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecord.java
@@ -30,6 +30,7 @@ import com.helion3.prism.api.data.PrismEvent;
 import com.helion3.prism.queues.RecordingQueue;
 import com.helion3.prism.util.DataQueries;
 import com.helion3.prism.util.DataUtil;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataContainer;
@@ -40,11 +41,14 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContext;
+import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -118,8 +122,20 @@ public class PrismRecord {
             return;
         }
 
-        // Queue the finished record for saving
-        RecordingQueue.add(getDataContainer());
+        // Prepare PrismRecord for sending to a PrismRecordEvent
+        PluginContainer plugin = Prism.getInstance().getPluginContainer();
+        EventContext eventContext = EventContext.builder().add(EventContextKeys.PLUGIN, plugin).build();
+
+        PrismRecordEvent event = new PrismRecordEvent(this,
+            Cause.of(eventContext, plugin));
+
+        // Tell Sponge that this PrismRecordEvent has occurred
+        Sponge.getEventManager().post(event);
+
+        if (!event.isCancelled()) {
+            // Queue the finished record for saving
+            RecordingQueue.add(getDataContainer());
+        }
     }
 
     /**

--- a/src/main/java/com/helion3/prism/api/records/PrismRecord.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecord.java
@@ -126,13 +126,13 @@ public class PrismRecord {
         PluginContainer plugin = Prism.getInstance().getPluginContainer();
         EventContext eventContext = EventContext.builder().add(EventContextKeys.PLUGIN, plugin).build();
 
-        PrismRecordEvent event = new PrismRecordEvent(this,
+        PrismRecordPreSaveEvent preSaveEvent = new PrismRecordPreSaveEvent(this,
             Cause.of(eventContext, plugin));
 
         // Tell Sponge that this PrismRecordEvent has occurred
-        Sponge.getEventManager().post(event);
+        Sponge.getEventManager().post(preSaveEvent);
 
-        if (!event.isCancelled()) {
+        if (!preSaveEvent.isCancelled()) {
             // Queue the finished record for saving
             RecordingQueue.add(getDataContainer());
         }

--- a/src/main/java/com/helion3/prism/api/records/PrismRecordEvent.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecordEvent.java
@@ -1,0 +1,56 @@
+package com.helion3.prism.api.records;
+
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+/**
+ * An event to be thrown when a PrismRecord is ready to be saved. Other
+ * plugins can catch this event and read the PrismRecord or cancel the
+ * event.
+ */
+public class PrismRecordEvent extends AbstractEvent implements Cancellable {
+
+  private boolean cancelled = false;
+  private final PrismRecord prismRecord;
+  private final Cause cause;
+
+  /**
+   * The constructor for a prism event to log the creation of a Prism Event
+   * to Sponge.
+   *
+   * @param prismRecord The record sent through the event
+   * @param cause       The cause of the event
+   */
+  PrismRecordEvent(PrismRecord prismRecord, Cause cause) {
+    this.prismRecord = prismRecord;
+    this.cause = cause;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return cancelled;
+  }
+
+  @Override
+  public void setCancelled(boolean cancel) {
+    this.cancelled = cancel;
+  }
+
+  @Override
+  @NonnullByDefault
+  public Cause getCause() {
+    return this.cause;
+  }
+
+  @Override
+  @NonnullByDefault
+  public Object getSource() {
+    return this.prismRecord.getSource();
+  }
+
+  public PrismRecord getPrismRecord() {
+    return prismRecord;
+  }
+}

--- a/src/main/java/com/helion3/prism/api/records/PrismRecordEvent.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecordEvent.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Prism, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2015 Helion3 http://helion3.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.helion3.prism.api.records;
 
 import org.spongepowered.api.event.Cancellable;
@@ -50,7 +74,13 @@ public class PrismRecordEvent extends AbstractEvent implements Cancellable {
     return this.prismRecord.getSource();
   }
 
+  /**
+   * Getter for the Prism Record saved to this event.
+   *
+   * @return the saved PrismRecord
+   */
   public PrismRecord getPrismRecord() {
     return prismRecord;
   }
+
 }

--- a/src/main/java/com/helion3/prism/api/records/PrismRecordPreSaveEvent.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecordPreSaveEvent.java
@@ -34,7 +34,7 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
  * plugins can catch this event and read the PrismRecord or cancel the
  * event.
  */
-public class PrismRecordEvent extends AbstractEvent implements Cancellable {
+public class PrismRecordPreSaveEvent extends AbstractEvent implements Cancellable {
 
   private boolean cancelled = false;
   private final PrismRecord prismRecord;
@@ -47,7 +47,7 @@ public class PrismRecordEvent extends AbstractEvent implements Cancellable {
    * @param prismRecord The record sent through the event
    * @param cause       The cause of the event
    */
-  PrismRecordEvent(PrismRecord prismRecord, Cause cause) {
+  PrismRecordPreSaveEvent(PrismRecord prismRecord, Cause cause) {
     this.prismRecord = prismRecord;
     this.cause = cause;
   }


### PR DESCRIPTION
Created a PrismRecordEvent which is thrown when a PrismRecord is about to be saved. Other plugins have the option to listen for it and cancel the event or read from the PrismRecord.