### PR TITLE
Call restore on main server thread

### DIFF
--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -149,22 +149,6 @@ public final class Prism {
         registerParameterHandler(new ParameterRadius());
         registerParameterHandler(new ParameterTime());
 
-        // Register PrismEvents
-        registerPrismEvent(PrismEvents.BLOCK_BREAK);
-        registerPrismEvent(PrismEvents.BLOCK_DECAY);
-        registerPrismEvent(PrismEvents.BLOCK_GROW);
-        registerPrismEvent(PrismEvents.BLOCK_PLACE);
-        registerPrismEvent(PrismEvents.ENTITY_DEATH);
-        registerPrismEvent(PrismEvents.COMMAND_EXECUTE);
-        registerPrismEvent(PrismEvents.INVENTORY_CLOSE);
-        registerPrismEvent(PrismEvents.INVENTORY_OPEN);
-        registerPrismEvent(PrismEvents.ITEM_DROP);
-        registerPrismEvent(PrismEvents.ITEM_INSERT);
-        registerPrismEvent(PrismEvents.ITEM_PICKUP);
-        registerPrismEvent(PrismEvents.ITEM_REMOVE);
-        registerPrismEvent(PrismEvents.PLAYER_DISCONNECT);
-        registerPrismEvent(PrismEvents.PLAYER_JOIN);
-
         // Register Commands
         Sponge.getCommandManager().register(this, PrismCommands.getCommand(), Reference.ID, "pr");
 

--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -124,6 +124,7 @@ public final class Prism {
     public void onConstruction(GameConstructionEvent event) {
         instance = this;
         configuration = new Configuration(getPath());
+        Sponge.getRegistry().registerModule(PrismEvent.class, PrismEvents.REGISTRY_MODULE);
     }
 
     @Listener

--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -355,32 +355,4 @@ public final class Prism {
         return getParameterHandlers().add(parameterHandler);
     }
 
-    /**
-     * Returns all currently registered prism events.
-     *
-     * @return List of {@link PrismEvent}
-     */
-    public Set<PrismEvent> getPrismEvents() {
-        return prismEvents;
-    }
-
-    public Optional<PrismEvent> getPrismEvent(String id) {
-        for (PrismEvent prismEvent : getPrismEvents()) {
-            if (StringUtils.equals(prismEvent.getId(), id)) {
-                return Optional.of(prismEvent);
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    /**
-     * Register a prism event.
-     *
-     * @param prismEvent
-     */
-    public boolean registerPrismEvent(PrismEvent prismEvent) {
-        Preconditions.checkNotNull(prismEvent);
-        return getPrismEvents().add(prismEvent);
-    }
 }

--- a/src/main/java/com/helion3/prism/api/data/PrismEvent.java
+++ b/src/main/java/com/helion3/prism/api/data/PrismEvent.java
@@ -25,37 +25,46 @@
 package com.helion3.prism.api.data;
 
 import com.helion3.prism.api.records.Result;
+import org.spongepowered.api.CatalogType;
 
-public class PrismEvent {
+import javax.annotation.Nonnull;
+
+public class PrismEvent implements CatalogType {
 
     private final String id;
     private final String name;
     private final String pastTense;
     private final Class<? extends Result> resultClass;
 
-    private PrismEvent(String id, String name, String pastTense, Class<? extends Result> resultClass) {
+    private PrismEvent(@Nonnull String id, @Nonnull String name, @Nonnull String pastTense, @Nonnull Class<? extends Result> resultClass) {
         this.id = id;
         this.name = name;
         this.pastTense = pastTense;
         this.resultClass = resultClass;
     }
 
-    public static PrismEvent of(String id, String name, String pastTense, Class<? extends Result> resultClass) {
+    public static PrismEvent of(@Nonnull String id, @Nonnull String name, @Nonnull String pastTense, @Nonnull Class<? extends Result> resultClass) {
         return new PrismEvent(id, name, pastTense, resultClass);
     }
 
+    @Override
+    @Nonnull
     public String getId() {
         return id;
     }
 
+    @Override
+    @Nonnull
     public String getName() {
         return name;
     }
 
+    @Nonnull
     public String getPastTense() {
         return pastTense;
     }
 
+    @Nonnull
     public Class<? extends Result> getResultClass() {
         return resultClass;
     }

--- a/src/main/java/com/helion3/prism/api/query/SQLQuery.java
+++ b/src/main/java/com/helion3/prism/api/query/SQLQuery.java
@@ -199,7 +199,7 @@ public class SQLQuery {
             // Where
             List<String> queryConditions = buildConditions(conditions);
             if (!queryConditions.isEmpty()) {
-                sql.append("WHERE ").append(String.join(" ", queryConditions).replaceFirst("AND ", "").replaceFirst("OR ", "")).append(" ");
+                sql.append("WHERE ").append(String.join(" ", queryConditions).replaceFirst("AND|OR ", "")).append(" ");
             }
 
             // Group By

--- a/src/main/java/com/helion3/prism/api/records/Actionable.java
+++ b/src/main/java/com/helion3/prism/api/records/Actionable.java
@@ -23,6 +23,8 @@
  */
 package com.helion3.prism.api.records;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface Actionable {
     /**
      * Reverses the result of this event on a subject
@@ -35,7 +37,7 @@ public interface Actionable {
      *
      * @return ActionableResult Results of applier action
      */
-    public ActionableResult rollback() throws Exception;
+    CompletableFuture<ActionableResult> rollback() throws Exception;
 
     /**
      * Re-applies the result of this event to a subject,
@@ -44,5 +46,5 @@ public interface Actionable {
      *
      * @return ActionableResult Results of applier action
      */
-    public ActionableResult restore() throws Exception;
+    CompletableFuture<ActionableResult> restore() throws Exception;
 }

--- a/src/main/java/com/helion3/prism/api/records/Actionable.java
+++ b/src/main/java/com/helion3/prism/api/records/Actionable.java
@@ -37,7 +37,7 @@ public interface Actionable {
      *
      * @return ActionableResult Results of applier action
      */
-    CompletableFuture<ActionableResult> rollback() throws Exception;
+    ActionableResult rollback() throws Exception;
 
     /**
      * Re-applies the result of this event to a subject,
@@ -46,5 +46,5 @@ public interface Actionable {
      *
      * @return ActionableResult Results of applier action
      */
-    CompletableFuture<ActionableResult> restore() throws Exception;
+    ActionableResult restore() throws Exception;
 }

--- a/src/main/java/com/helion3/prism/api/records/BlockResult.java
+++ b/src/main/java/com/helion3/prism/api/records/BlockResult.java
@@ -24,8 +24,10 @@
 package com.helion3.prism.api.records;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Preconditions;
+import com.helion3.prism.Prism;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.data.DataView;
@@ -35,6 +37,7 @@ import org.spongepowered.api.block.BlockSnapshot.Builder;
 
 import com.helion3.prism.util.BlockUtil;
 import com.helion3.prism.util.DataQueries;
+import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.world.BlockChangeFlags;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -46,11 +49,14 @@ import javax.annotation.Nonnull;
  */
 public class BlockResult extends ResultComplete implements Actionable {
     @Override
-    public ActionableResult rollback() throws Exception {
+    public CompletableFuture<ActionableResult> rollback() throws Exception {
+        CompletableFuture<ActionableResult> result = new CompletableFuture<>();
+
         Optional<Object> optionalOriginal = data.get(DataQueries.OriginalBlock);
 
         if (!optionalOriginal.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID));
+            return result;
         }
 
         // Our data is stored with a different structure, so we'll need
@@ -60,7 +66,8 @@ public class BlockResult extends ResultComplete implements Actionable {
         // Build World UUID / Vec3 data BlockSnapshot expects
         Optional<Object> optionalLocation = data.get(DataQueries.Location);
         if (!optionalLocation.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID_LOCATION);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID_LOCATION));
+            return result;
         }
 
         // Format
@@ -68,34 +75,42 @@ public class BlockResult extends ResultComplete implements Actionable {
 
         Optional<BlockSnapshot> optionalSnapshot = Sponge.getRegistry().createBuilder(Builder.class).build(finalBlock);
         if (!optionalSnapshot.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID));
+            return result;
         }
 
         BlockSnapshot snapshot = optionalSnapshot.get();
 
         if (!snapshot.getLocation().isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID_LOCATION);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID_LOCATION));
+            return result;
         }
 
         Location<World> location = snapshot.getLocation().get();
 
         // Filter unsafe blocks
         if (BlockUtil.rejectIllegalApplierBlock(snapshot.getState().getType())) {
-            return ActionableResult.skipped(SkipReason.ILLEGAL_BLOCK);
+            result.complete(ActionableResult.skipped(SkipReason.ILLEGAL_BLOCK));
+            return result;
         }
 
-        // Current block in this space.
-        BlockSnapshot original = location.getBlock().snapshotFor(location);
+        Task.builder().execute(() -> {
+            // Current block in this space.
+            BlockSnapshot original = location.getBlock().snapshotFor(location);
 
-        // Actually restore!
-        if (!optionalSnapshot.get().restore(true, BlockChangeFlags.NONE)) {
-            return ActionableResult.skipped(SkipReason.UNKNOWN);
-        }
+            // Actually restore!
+            if (!optionalSnapshot.get().restore(true, BlockChangeFlags.NONE)) {
+                result.complete(ActionableResult.skipped(SkipReason.UNKNOWN));
+                return;
+            }
 
-        // Final block in this space.
-        BlockSnapshot resultingBlock = location.getBlock().snapshotFor(location);
+            // Final block in this space.
+            BlockSnapshot resultingBlock = location.getBlock().snapshotFor(location);
 
-        return ActionableResult.success(new Transaction<>(original, resultingBlock));
+            result.complete(ActionableResult.success(new Transaction<>(original, resultingBlock)));
+        }).submit(Prism.getInstance());
+
+        return result;
     }
 
     public DataView formatBlockData(DataView finalBlock, @Nonnull Object optionalLocation) {
@@ -125,10 +140,14 @@ public class BlockResult extends ResultComplete implements Actionable {
     }
 
     @Override
-    public ActionableResult restore() throws Exception {
+    public CompletableFuture<ActionableResult> restore() throws Exception {
+
+        CompletableFuture<ActionableResult> result = new CompletableFuture<>();
+
         Optional<Object> optionalFinal = data.get(DataQueries.ReplacementBlock);
         if (!optionalFinal.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID));
+            return result;
         }
 
         // Our data is stored with a different structure, so we'll need
@@ -138,7 +157,8 @@ public class BlockResult extends ResultComplete implements Actionable {
         // Build World UUID / Vec3 data BlockSnapshot expects
         Optional<Object> optionalLocation = data.get(DataQueries.Location);
         if (!optionalLocation.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID_LOCATION);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID_LOCATION));
+            return result;
         }
 
         // Format
@@ -146,33 +166,42 @@ public class BlockResult extends ResultComplete implements Actionable {
 
         Optional<BlockSnapshot> optionalSnapshot = Sponge.getRegistry().createBuilder(Builder.class).build(finalBlock);
         if (!optionalSnapshot.isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID));
+            return result;
         }
 
         BlockSnapshot snapshot = optionalSnapshot.get();
 
         if (!snapshot.getLocation().isPresent()) {
-            return ActionableResult.skipped(SkipReason.INVALID_LOCATION);
+            result.complete(ActionableResult.skipped(SkipReason.INVALID_LOCATION));
+            return result;
         }
 
         Location<World> location = snapshot.getLocation().get();
 
         // Filter unsafe blocks
         if (BlockUtil.rejectIllegalApplierBlock(snapshot.getState().getType())) {
-            return ActionableResult.skipped(SkipReason.ILLEGAL_BLOCK);
+            result.complete(ActionableResult.skipped(SkipReason.ILLEGAL_BLOCK));
+            return result;
         }
 
         // Current block in this space.
         BlockSnapshot original = location.getBlock().snapshotFor(location);
 
-        // Actually restore!
-        if (!optionalSnapshot.get().restore(true, BlockChangeFlags.NONE)) {
-            return ActionableResult.skipped(SkipReason.UNKNOWN);
-        }
+        Task.builder().execute(() -> {
+            // Actually restore!
+            if (!optionalSnapshot.get().restore(true, BlockChangeFlags.NONE)) {
+                result.complete(ActionableResult.skipped(SkipReason.UNKNOWN));
+                return;
+            }
 
-        // Final block in this space.
-        BlockSnapshot resultingBlock = location.getBlock().snapshotFor(location);
+            // Final block in this space.
+            BlockSnapshot resultingBlock = location.getBlock().snapshotFor(location);
+            result.complete(ActionableResult.success(new Transaction<>(original, resultingBlock)));
 
-        return ActionableResult.success(new Transaction<>(original, resultingBlock));
+        }).submit(Prism.getInstance());
+
+        return result;
+
     }
 }

--- a/src/main/java/com/helion3/prism/api/records/PrismRecord.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecord.java
@@ -30,7 +30,6 @@ import com.helion3.prism.api.data.PrismEvent;
 import com.helion3.prism.queues.RecordingQueue;
 import com.helion3.prism.util.DataQueries;
 import com.helion3.prism.util.DataUtil;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataContainer;
@@ -41,14 +40,11 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.event.cause.EventContext;
-import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
-import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -122,20 +118,8 @@ public class PrismRecord {
             return;
         }
 
-        // Prepare PrismRecord for sending to a PrismRecordEvent
-        PluginContainer plugin = Prism.getInstance().getPluginContainer();
-        EventContext eventContext = EventContext.builder().add(EventContextKeys.PLUGIN, plugin).build();
-
-        PrismRecordPreSaveEvent preSaveEvent = new PrismRecordPreSaveEvent(this,
-            Cause.of(eventContext, plugin));
-
-        // Tell Sponge that this PrismRecordEvent has occurred
-        Sponge.getEventManager().post(preSaveEvent);
-
-        if (!preSaveEvent.isCancelled()) {
-            // Queue the finished record for saving
-            RecordingQueue.add(getDataContainer());
-        }
+        // Queue the finished record for saving
+        RecordingQueue.add(this);
     }
 
     /**

--- a/src/main/java/com/helion3/prism/api/records/PrismRecord.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecord.java
@@ -30,6 +30,7 @@ import com.helion3.prism.api.data.PrismEvent;
 import com.helion3.prism.queues.RecordingQueue;
 import com.helion3.prism.util.DataQueries;
 import com.helion3.prism.util.DataUtil;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataContainer;
@@ -350,7 +351,7 @@ public class PrismRecord {
          * @return A new prism record
          */
         public PrismRecord build() {
-            Preconditions.checkState(Prism.getInstance().getPrismEvent(getEvent()).isPresent(), getEvent() + " is not registered");
+            Preconditions.checkState(Sponge.getRegistry().getType(PrismEvent.class, getEvent()).isPresent(), getEvent() + " is not registered");
             return new PrismRecord(getEvent(), getSource(), getDataContainer());
         }
 

--- a/src/main/java/com/helion3/prism/api/records/PrismRecordPreSaveEvent.java
+++ b/src/main/java/com/helion3/prism/api/records/PrismRecordPreSaveEvent.java
@@ -27,7 +27,8 @@ package com.helion3.prism.api.records;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.impl.AbstractEvent;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+import javax.annotation.Nonnull;
 
 /**
  * An event to be thrown when a PrismRecord is ready to be saved. Other
@@ -47,7 +48,7 @@ public class PrismRecordPreSaveEvent extends AbstractEvent implements Cancellabl
    * @param prismRecord The record sent through the event
    * @param cause       The cause of the event
    */
-  PrismRecordPreSaveEvent(PrismRecord prismRecord, Cause cause) {
+  public PrismRecordPreSaveEvent(PrismRecord prismRecord, Cause cause) {
     this.prismRecord = prismRecord;
     this.cause = cause;
   }
@@ -62,14 +63,14 @@ public class PrismRecordPreSaveEvent extends AbstractEvent implements Cancellabl
     this.cancelled = cancel;
   }
 
+  @Nonnull
   @Override
-  @NonnullByDefault
   public Cause getCause() {
     return this.cause;
   }
 
+  @Nonnull
   @Override
-  @NonnullByDefault
   public Object getSource() {
     return this.prismRecord.getSource();
   }

--- a/src/main/java/com/helion3/prism/api/records/Result.java
+++ b/src/main/java/com/helion3/prism/api/records/Result.java
@@ -24,9 +24,9 @@
 
 package com.helion3.prism.api.records;
 
-import com.helion3.prism.Prism;
 import com.helion3.prism.api.data.PrismEvent;
 import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 
 import com.helion3.prism.util.DataQueries;
@@ -42,7 +42,7 @@ public abstract class Result {
      */
     public String getEventVerb() {
         String id = getEventId();
-        PrismEvent event = Prism.getInstance().getPrismEvent(id).orElse(null);
+        PrismEvent event = Sponge.getRegistry().getType(PrismEvent.class, id).orElse(null);
         if (event != null) {
             if (StringUtils.isNotBlank(event.getPastTense())) {
                 return event.getPastTense();
@@ -72,7 +72,7 @@ public abstract class Result {
      */
     public String getEventName() {
         String id = getEventId();
-        PrismEvent event = Prism.getInstance().getPrismEvent(id).orElse(null);
+        PrismEvent event = Sponge.getRegistry().getType(PrismEvent.class, id).orElse(null);
         if (event != null && StringUtils.isNotBlank(event.getName())) {
             return event.getName();
         }
@@ -129,7 +129,7 @@ public abstract class Result {
         }
 
         // Pull record class for this event, if any
-        Class<? extends Result> resultRecordClass = Prism.getInstance().getPrismEvent(id)
+        Class<? extends Result> resultRecordClass = Sponge.getRegistry().getType(PrismEvent.class, id)
                 .map(PrismEvent::getResultClass)
                 .orElseThrow(() -> new UnsupportedOperationException(id + " is not supported"));
 

--- a/src/main/java/com/helion3/prism/queues/RecordingQueue.java
+++ b/src/main/java/com/helion3/prism/queues/RecordingQueue.java
@@ -25,25 +25,30 @@ package com.helion3.prism.queues;
 
 import java.util.concurrent.LinkedBlockingQueue;
 
+import com.helion3.prism.api.records.PrismRecord;
 import org.spongepowered.api.data.DataContainer;
 
 public class RecordingQueue {
 
-    private static final LinkedBlockingQueue<DataContainer> queue = new LinkedBlockingQueue<>();
+    private static final LinkedBlockingQueue<PrismRecord> queue = new LinkedBlockingQueue<>();
 
     private RecordingQueue(){}
 
     /**
      * Adds a new Event to the recording queue.
      *
-     * @param container Event to be queued for database write
+     * @param record Event to be queued for database write
      */
-    public static void add(final DataContainer container) {
-        if (container == null) {
-            throw new IllegalArgumentException("Null container given to Prism recording queue.");
+    public static void add(final PrismRecord record) {
+        if (record == null) {
+            throw new IllegalArgumentException("null PrismRecord given to Prism recording queue");
         }
 
-        queue.add(container);
+        if (record.getDataContainer() == null) {
+            throw new IllegalArgumentException("PrismRecord with null container given to Prism recording queue.");
+        }
+
+        queue.add(record);
     }
 
     /**
@@ -51,7 +56,7 @@ public class RecordingQueue {
      *
      * @return Current unsaved {@link DataContainer} queue
      */
-    public static LinkedBlockingQueue<DataContainer> getQueue() {
+    public static LinkedBlockingQueue<PrismRecord> getQueue() {
         return queue;
     }
 }

--- a/src/main/java/com/helion3/prism/util/PrismEvents.java
+++ b/src/main/java/com/helion3/prism/util/PrismEvents.java
@@ -24,10 +24,19 @@
 
 package com.helion3.prism.util;
 
+import com.google.common.collect.Lists;
 import com.helion3.prism.api.data.PrismEvent;
 import com.helion3.prism.api.records.BlockResult;
 import com.helion3.prism.api.records.EntityResult;
 import com.helion3.prism.api.records.ResultComplete;
+import org.spongepowered.api.registry.CatalogRegistryModule;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public final class PrismEvents {
 
@@ -61,4 +70,40 @@ public final class PrismEvents {
     public static final PrismEvent PLAYER_DISCONNECT = PrismEvent.of("disconnect", "Player Disconnect", "left", ResultComplete.class);
 
     public static final PrismEvent PLAYER_JOIN = PrismEvent.of("join", "Player Join", "joined", ResultComplete.class);
+
+    public static final CatalogRegistryModule<PrismEvent> REGISTRY_MODULE = new
+        CatalogRegistryModule<PrismEvent>() {
+            private final List<PrismEvent> prismEvents = Lists.newArrayList(
+                BLOCK_BREAK,
+                BLOCK_DECAY,
+                BLOCK_GROW,
+                BLOCK_PLACE,
+                ENTITY_DEATH,
+                COMMAND_EXECUTE,
+                INVENTORY_CLOSE,
+                INVENTORY_OPEN,
+                ITEM_DROP,
+                ITEM_INSERT,
+                ITEM_PICKUP,
+                ITEM_REMOVE,
+                PLAYER_DISCONNECT,
+                PLAYER_JOIN
+            );
+            private final Map<String, PrismEvent> prismEventMap = new HashMap<String, PrismEvent>() {{
+              prismEvents.forEach(prismEvent -> put(prismEvent.getId(), prismEvent));
+            }};
+
+            @Nonnull
+            @Override
+            public Optional<PrismEvent> getById(@Nonnull String id) {
+                return Optional.ofNullable(prismEventMap.get(id));
+            }
+
+            @Nonnull
+            @Override
+            public Collection<PrismEvent> getAll() {
+                return prismEvents;
+            }
+        };
+
 }


### PR DESCRIPTION
Errors are thrown sometimes when using restoration because Sponge throws a fit for block 'restore' done asynchronously. I use the Sponge Scheduler to reschedule the restoration on the main server thread. Also, to support the API and other plugins, I had the GriefEvent implement the CategoryType for more robust registration.