### PR TITLE
Introducing ChangeSignListener for handling data when placing signs

### DIFF
--- a/src/main/java/com/helion3/prism/Prism.java
+++ b/src/main/java/com/helion3/prism/Prism.java
@@ -50,6 +50,7 @@ import com.helion3.prism.commands.PrismCommands;
 import com.helion3.prism.configuration.Config;
 import com.helion3.prism.configuration.Configuration;
 import com.helion3.prism.listeners.ChangeBlockListener;
+import com.helion3.prism.listeners.ChangeSignListener;
 import com.helion3.prism.listeners.EntityListener;
 import com.helion3.prism.listeners.InventoryListener;
 import com.helion3.prism.listeners.RequiredInteractListener;
@@ -171,6 +172,7 @@ public final class Prism {
         Sponge.getEventManager().registerListeners(getPluginContainer(), new ChangeBlockListener());
         Sponge.getEventManager().registerListeners(getPluginContainer(), new EntityListener());
         Sponge.getEventManager().registerListeners(getPluginContainer(), new InventoryListener());
+//        Sponge.getEventManager().registerListeners(getPluginContainer(), new ChangeSignListener());
 
         // Events required for internal operation
         Sponge.getEventManager().registerListeners(getPluginContainer(), new RequiredInteractListener());

--- a/src/main/java/com/helion3/prism/api/records/SignResult.java
+++ b/src/main/java/com/helion3/prism/api/records/SignResult.java
@@ -1,0 +1,19 @@
+package com.helion3.prism.api.records;
+
+public class SignResult extends ResultComplete implements Actionable {
+  @Override
+  public ActionableResult rollback() throws Exception {
+
+    // TODO implement
+    return ActionableResult.skipped(SkipReason.UNIMPLEMENTED);
+
+  }
+
+  @Override
+  public ActionableResult restore() throws Exception {
+
+    // TODO implement
+    return ActionableResult.skipped(SkipReason.UNIMPLEMENTED);
+
+  }
+}

--- a/src/main/java/com/helion3/prism/configuration/Configuration.java
+++ b/src/main/java/com/helion3/prism/configuration/Configuration.java
@@ -135,6 +135,7 @@ public class Configuration {
             getConfig().getEventCategory().setBlockDecay(events.getNode("decay").getBoolean(true));
             getConfig().getEventCategory().setBlockGrow(events.getNode("grow").getBoolean(true));
             getConfig().getEventCategory().setBlockPlace(events.getNode("place").getBoolean(true));
+            getConfig().getEventCategory().setSignChange(events.getNode("signchange").getBoolean(true));
             getConfig().getEventCategory().setCommandExecute(events.getNode("command").getBoolean(false));
             getConfig().getEventCategory().setEntityDeath(events.getNode("death").getBoolean(true));
             getConfig().getEventCategory().setInventoryClose(events.getNode("close").getBoolean(false));

--- a/src/main/java/com/helion3/prism/configuration/category/EventCategory.java
+++ b/src/main/java/com/helion3/prism/configuration/category/EventCategory.java
@@ -42,6 +42,9 @@ public class EventCategory {
     @Setting(value = "block-place", comment = "Log when blocks are placed")
     private boolean blockPlace = true;
 
+    @Setting(value = "sign-change", comment = "Log when a sign is changed")
+    private boolean signChange = true;
+
     @Setting(value = "command-execute", comment = "Log when commands are executed")
     private boolean commandExecute = false;
 
@@ -102,6 +105,14 @@ public class EventCategory {
 
     public void setBlockPlace(boolean blockPlace) {
         this.blockPlace = blockPlace;
+    }
+
+    public boolean isSignChange() {
+        return signChange;
+    }
+
+    public void setSignChange(boolean signChange) {
+        this.signChange = signChange;
     }
 
     public boolean isCommandExecute() {

--- a/src/main/java/com/helion3/prism/listeners/ChangeSignListener.java
+++ b/src/main/java/com/helion3/prism/listeners/ChangeSignListener.java
@@ -1,0 +1,47 @@
+package com.helion3.prism.listeners;
+
+import com.helion3.prism.Prism;
+import org.spongepowered.api.block.tileentity.Sign;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.SignData;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.block.tileentity.ChangeSignEvent;
+
+public class ChangeSignListener {
+
+  /**
+   * Listens to the base change block event.
+   *
+   * @param event ChangeBlockEvent
+   */
+  @Listener(order = Order.POST)
+  public void onChangeSign(ChangeSignEvent event) {
+    if (event.getCause().first(Player.class).map(Player::getUniqueId).map(Prism.getInstance().getActiveWands()::contains).orElse(false)) {
+      // Cancel and exit event here, not supposed to place/track a block with an active wand.
+      event.setCancelled(true);
+      return;
+    }
+
+    if (!Prism.getInstance().getConfig().getEventCategory().isSignChange()) {
+      return;
+    }
+    Sign tileEntity = event.getTargetTile();
+
+    // TODO implement
+
+    // Get relevant data from this event -- namely, the changed sign data
+    SignData originalSignData = tileEntity.getSignData();
+    SignData finalSignData = event.getText();
+
+    // Create prism record
+//    PrismRecord.create()
+//        .source(event.getCause())
+//        .signOriginal(originalSignData)
+//        .signReplacement(finalSignData)
+//        .location(tileEntity.getLocation())
+//        .event(PrismEvents.SIGN_CHANGE)
+//        .target(tileEntity.getBlock().getId().replace("_", " "))
+//        .buildAndSave();
+  }
+}


### PR DESCRIPTION
Currently, when placing signs, there is no text data stored in the event because the player confirms the text after the place event. This throws a [ChangeSignEvent](https://jd.spongepowered.org/5.0.0/org/spongepowered/api/event/block/tileentity/ChangeSignEvent.html) which contains the data, so in order to allow for correct restoration of events through Prism commands, this text data needs to be included in some event. The solution is not yet clear to me, but I hope to continue working on the solution throughout this pull request.