### PR TITLE
Added blacklist configuration

### DIFF
--- a/src/main/java/com/helion3/prism/configuration/Configuration.java
+++ b/src/main/java/com/helion3/prism/configuration/Configuration.java
@@ -24,12 +24,15 @@
 
 package com.helion3.prism.configuration;
 
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
 import com.helion3.prism.Prism;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMapper;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.Path;
@@ -156,6 +159,15 @@ public class Configuration {
         if (!query.isVirtual()) {
             getConfig().getLimitCategory().setMaximumActionable(query.getNode("actionable", "limit").getInt(10000));
             getConfig().getLimitCategory().setMaximumLookup(query.getNode("lookup", "limit").getInt(1000));
+        }
+
+        ConfigurationNode blacklist = configurationNode.getNode("blacklist");
+        if (!blacklist.isVirtual()) {
+            try {
+                getConfig().getGeneralCategory().setBlacklist(blacklist.getList(TypeToken.of(String.class), Lists.newArrayList()));
+            } catch (ObjectMappingException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/com/helion3/prism/configuration/category/GeneralCategory.java
+++ b/src/main/java/com/helion3/prism/configuration/category/GeneralCategory.java
@@ -24,8 +24,11 @@
 
 package com.helion3.prism.configuration.category;
 
+import com.google.common.collect.Lists;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.List;
 
 @ConfigSerializable
 public class GeneralCategory {
@@ -38,6 +41,9 @@ public class GeneralCategory {
 
     @Setting(value = "schema-version")
     private int schemaVersion = 2;
+
+    @Setting(value = "blacklist")
+    private List<String> blacklist = Lists.newArrayList();
 
     public String getDateFormat() {
         return dateFormat;
@@ -61,5 +67,13 @@ public class GeneralCategory {
 
     public void setSchemaVersion(int schemaVersion) {
         this.schemaVersion = schemaVersion;
+    }
+
+    public List<String> getBlacklist() {
+        return blacklist;
+    }
+
+    public void setBlacklist(List<String> blacklist) {
+        this.blacklist = blacklist;
     }
 }

--- a/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
+++ b/src/main/java/com/helion3/prism/listeners/ChangeBlockListener.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
+import org.spongepowered.api.plugin.PluginContainer;
 
 public class ChangeBlockListener {
 
@@ -46,6 +47,13 @@ public class ChangeBlockListener {
      */
     @Listener(order = Order.POST)
     public void onChangeBlock(ChangeBlockEvent event) {
+
+        if (event.getCause().allOf(PluginContainer.class).stream().map(PluginContainer::getId).anyMatch(id ->
+                Prism.getInstance().getConfig().getGeneralCategory().getBlacklist().contains(id))) {
+            // Don't do anything
+            return;
+        }
+
         if (event.getCause().first(Player.class).map(Player::getUniqueId).map(Prism.getInstance().getActiveWands()::contains).orElse(false)) {
             // Cancel and exit event here, not supposed to place/track a block with an active wand.
             event.setCancelled(true);


### PR DESCRIPTION
Some plugins create events that has players in the cause stack but shouldn't be logged by Prism. In the configuration, plugin ids can be added to the blacklist and the block events given by the respective plugins will not be handled.  